### PR TITLE
Redesign onboarding and dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ docker-compose up -d
    - Collection names
    - IPTorrents scanner settings (optional)
 
+## Accessing the Web UI
+
+FELScanner ships with a full-featured single-page interface that lives at the root URL of the server. Once the Flask app is running you can open `http://<host>:5000/` to:
+
+- Launch the guided setup wizard for first-time configuration.
+- Trigger scans, verify Plex collections, or start the IPTorrents monitor.
+- Download generated reports and review recent Dolby Vision/Atmos findings.
+- Adjust Plex, Telegram, and IPTorrents settings directly from the browser without touching configuration files.
+
+The UI is backed by the endpoints defined in `app.py` and the assets under `templates/` and `static/`, so hosting the application through Docker or via `python app.py` automatically exposes the management dashboard.
+
 ## Persistent Data
 
 The application stores its data in the following locations:

--- a/app.py
+++ b/app.py
@@ -2192,16 +2192,8 @@ if app.config['SETUP_COMPLETED'] and app.config['AUTO_START_MODE'] == 'monitor':
 # @app.before_first_request
 # def init_iptscanner():
 
-# New initialization approach
+# Ensure the IPT scanner is ready both for direct execution and WSGI imports
 init_iptscanner()
-
-# Add this at the bottom of the file, before app.run()
-if __name__ == "__main__":
-    # Initialize IPTScanner
-    init_iptscanner()
-    
-    # Start the app
-    app.run(host='0.0.0.0', port=5000, debug=True)
 
 @app.route('/api/iptscanner/test-run', methods=['POST'])
 def test_run_iptscanner():
@@ -2249,3 +2241,8 @@ def test_run_iptscanner():
     except Exception as e:
         app.logger.error(f"Error in test_run_iptscanner: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+if __name__ == "__main__":
+    # Start the app
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,0 +1,1085 @@
+:root {
+    --page-bg: #050816;
+    --page-gradient: radial-gradient(circle at top left, rgba(56, 189, 248, 0.25), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(99, 102, 241, 0.25), transparent 60%);
+    --surface-primary: rgba(15, 23, 42, 0.85);
+    --surface-muted: rgba(30, 41, 59, 0.65);
+    --surface-border: rgba(148, 163, 184, 0.22);
+    --surface-border-strong: rgba(148, 163, 184, 0.4);
+    --surface-highlight: rgba(148, 163, 184, 0.14);
+    --text-primary: #f8fafc;
+    --text-muted: rgba(226, 232, 240, 0.75);
+    --text-subtle: rgba(148, 163, 184, 0.82);
+    --accent: #38bdf8;
+    --accent-strong: #0ea5e9;
+    --accent-gradient: linear-gradient(135deg, #38bdf8, #6366f1);
+    --accent-soft: rgba(56, 189, 248, 0.2);
+    --success: #34d399;
+    --danger: #f87171;
+    --warning: #fbbf24;
+    --card-radius: 22px;
+    --shadow-lg: 0 28px 80px rgba(15, 23, 42, 0.55);
+}
+
+body {
+    background: var(--page-gradient), var(--page-bg);
+    color: var(--text-primary);
+    font-family: 'Inter', system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    padding: 32px 0 80px;
+    min-height: 100vh;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+a {
+    color: var(--accent);
+    transition: color 0.2s ease;
+}
+
+a:hover {
+    color: var(--accent-strong);
+}
+
+.container {
+    max-width: 1180px;
+    position: relative;
+    z-index: 1;
+}
+
+.hero-surface {
+    background: linear-gradient(140deg, rgba(59, 130, 246, 0.35), rgba(14, 165, 233, 0.12));
+    border-radius: var(--card-radius);
+    border: 1px solid var(--surface-border);
+    padding: 3rem;
+    box-shadow: var(--shadow-lg);
+    position: relative;
+    overflow: hidden;
+}
+
+.hero-surface::after {
+    content: '';
+    position: absolute;
+    top: -40%;
+    right: -30%;
+    width: 70%;
+    height: 160%;
+    background: radial-gradient(circle at center, rgba(56, 189, 248, 0.35), transparent 65%);
+    opacity: 0.85;
+    filter: blur(0.5px);
+}
+
+.hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--accent);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.78rem;
+}
+
+.hero-title {
+    font-size: clamp(2.3rem, 5vw, 3.4rem);
+    font-weight: 700;
+    margin: 1.2rem 0 1rem;
+}
+
+.hero-subtitle {
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    max-width: 540px;
+    line-height: 1.6;
+}
+
+.hero-actions .btn {
+    border-radius: 999px;
+    font-weight: 600;
+    padding-inline: 1.5rem;
+    padding-block: 0.75rem;
+}
+
+.hero-actions .btn.btn-primary {
+    background: var(--accent-gradient);
+    border: none;
+    box-shadow: 0 16px 35px rgba(56, 189, 248, 0.35);
+}
+
+.hero-actions .btn.btn-outline-light {
+    border-color: rgba(248, 250, 252, 0.45);
+    color: var(--text-primary);
+    backdrop-filter: blur(6px);
+}
+
+.hero-footnote {
+    color: var(--text-subtle);
+    font-size: 0.9rem;
+}
+
+.hero-metric-grid {
+    margin-top: 1.5rem;
+}
+
+.hero-metric-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.2rem 1.4rem;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid var(--surface-border);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.hero-metric-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 24px 56px rgba(15, 23, 42, 0.45);
+}
+
+.hero-metric-card.accent {
+    background: linear-gradient(140deg, rgba(56, 189, 248, 0.28), rgba(99, 102, 241, 0.18));
+    border-color: rgba(56, 189, 248, 0.45);
+}
+
+.hero-metric-card.status {
+    justify-content: flex-start;
+    gap: 1.1rem;
+    background: rgba(15, 23, 42, 0.72);
+}
+
+.hero-metric-icon {
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    background: rgba(56, 189, 248, 0.12);
+    color: var(--accent);
+}
+
+.hero-metric-card.accent .hero-metric-icon {
+    background: rgba(99, 102, 241, 0.18);
+    color: #f9fafb;
+}
+
+.hero-metric-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+}
+
+.hero-metric-value {
+    font-size: clamp(1.6rem, 2.2vw, 2rem);
+    font-weight: 700;
+    margin-bottom: 0.2rem;
+}
+
+.hero-metric-caption {
+    color: var(--text-muted);
+    font-size: 0.88rem;
+    margin-bottom: 0;
+}
+
+.hero-metric-subtle {
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+    margin-bottom: 0;
+}
+
+.hero-metric-pills {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.55rem;
+}
+
+.metric-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.45);
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.hero-metric-card.accent .metric-pill {
+    background: rgba(15, 23, 42, 0.52);
+    border-color: rgba(248, 250, 252, 0.2);
+}
+
+.metric-pill-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(226, 232, 240, 0.75);
+}
+
+.metric-pill-value {
+    font-size: 1rem;
+}
+
+.hero-status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-transform: capitalize;
+    background: rgba(148, 163, 184, 0.16);
+    color: var(--text-primary);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    margin-bottom: 0.5rem;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.hero-status-chip.idle {
+    background: rgba(148, 163, 184, 0.16);
+    border-color: rgba(148, 163, 184, 0.32);
+}
+
+.hero-status-chip.scanning,
+.hero-status-chip.verifying {
+    background: rgba(56, 189, 248, 0.18);
+    border-color: rgba(56, 189, 248, 0.42);
+    color: #f8fafc;
+}
+
+.hero-status-chip.monitoring {
+    background: rgba(52, 211, 153, 0.2);
+    border-color: rgba(52, 211, 153, 0.5);
+    color: #ecfdf5;
+}
+
+.hero-status-copy {
+    display: flex;
+    flex-direction: column;
+}
+
+.hero-status-copy .hero-metric-caption {
+    margin-bottom: 0.15rem;
+}
+
+.hero-summary {
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: 20px;
+    border: 1px solid var(--surface-border);
+    backdrop-filter: blur(18px);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+}
+
+.hero-summary .card-body {
+    position: relative;
+    z-index: 1;
+}
+
+.hero-summary::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.15), transparent 55%);
+    opacity: 0.9;
+}
+
+.hero-checklist {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.hero-checklist li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--text-muted);
+    margin-bottom: 0.6rem;
+    font-weight: 500;
+}
+
+.hero-checklist li i {
+    color: var(--accent);
+}
+
+.wizard-shell {
+    background: rgba(15, 23, 42, 0.62);
+    border-radius: var(--card-radius);
+    border: 1px solid var(--surface-border);
+    padding: 2.5rem 2rem;
+    box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(22px);
+}
+
+.wizard-card {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+.wizard-card .card-body {
+    background: rgba(15, 23, 42, 0.52);
+    border-radius: 20px;
+    border: 1px solid var(--surface-border);
+    backdrop-filter: blur(20px);
+    padding: 2rem;
+}
+
+.wizard-kicker {
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: var(--text-subtle);
+    font-size: 0.78rem;
+}
+
+.wizard-title {
+    font-size: 1.8rem;
+    font-weight: 600;
+    margin: 0.75rem 0 0.6rem;
+}
+
+.wizard-subtitle {
+    color: var(--text-muted);
+    margin-bottom: 1.5rem;
+}
+
+.setup-progress {
+    position: relative;
+    margin-bottom: 2.2rem;
+    padding-bottom: 1.5rem;
+}
+
+.setup-progress-track {
+    position: absolute;
+    top: 24px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: rgba(148, 163, 184, 0.18);
+}
+
+.setup-progress-fill {
+    position: absolute;
+    top: 24px;
+    left: 0;
+    height: 2px;
+    width: 0%;
+    background: var(--accent-gradient);
+    transition: width 0.4s ease;
+}
+
+.setup-progress-steps {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    position: relative;
+    z-index: 1;
+}
+
+.setup-progress-step {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    text-align: left;
+    padding: 0;
+}
+
+.setup-progress-step .step-circle {
+    width: 48px;
+    height: 48px;
+    border-radius: 16px;
+    border: 1px solid var(--surface-border);
+    background: rgba(15, 23, 42, 0.75);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--text-muted);
+}
+
+.setup-progress-step .step-circle i {
+    font-size: 1.1rem;
+}
+
+.setup-progress-step .step-label {
+    font-weight: 600;
+    font-size: 0.82rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.setup-progress-step .step-caption {
+    font-size: 0.78rem;
+    color: var(--text-subtle);
+}
+
+.setup-progress-step.active .step-circle {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent);
+    transform: translateY(-2px) scale(1.05);
+    box-shadow: 0 0 0 8px rgba(56, 189, 248, 0.14);
+}
+
+.setup-progress-step.active .step-label {
+    color: var(--text-primary);
+}
+
+.setup-progress-step.completed .step-circle {
+    background: rgba(52, 211, 153, 0.18);
+    border-color: rgba(52, 211, 153, 0.55);
+    color: var(--success);
+}
+
+.setup-progress-step.completed .step-label {
+    color: var(--success);
+}
+
+.setup-progress-step:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.setup-step {
+    display: none;
+    animation: fadeInUp 0.35s ease;
+}
+
+.setup-step.active {
+    display: block;
+}
+
+.step-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.step-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 18px;
+    background: rgba(56, 189, 248, 0.15);
+    color: var(--accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    flex-shrink: 0;
+}
+
+.step-title {
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+    font-size: 1.3rem;
+}
+
+.step-description {
+    color: var(--text-muted);
+    margin-bottom: 0;
+}
+
+.form-control,
+.form-select,
+.input-group-text {
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid var(--surface-border);
+    color: var(--text-primary);
+    border-radius: 14px;
+    padding: 0.75rem 1rem;
+}
+
+.form-control:focus,
+.form-select:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 0.2rem rgba(56, 189, 248, 0.18);
+    background: rgba(15, 23, 42, 0.9);
+    color: var(--text-primary);
+}
+
+.form-text {
+    color: var(--text-subtle);
+}
+
+.form-check-input {
+    background-color: rgba(15, 23, 42, 0.55);
+    border-color: var(--surface-border);
+}
+
+.form-check-input:checked {
+    background-color: var(--accent);
+    border-color: var(--accent);
+}
+
+.btn {
+    border-radius: 14px;
+    padding: 0.65rem 1.25rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+.btn-primary {
+    border: none;
+    background: var(--accent-gradient);
+    box-shadow: 0 16px 35px rgba(56, 189, 248, 0.35);
+}
+
+.btn-success {
+    border: none;
+    background: linear-gradient(135deg, #34d399, #10b981);
+    box-shadow: 0 16px 35px rgba(16, 185, 129, 0.25);
+}
+
+.btn-secondary {
+    background: rgba(71, 85, 105, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    color: var(--text-primary);
+}
+
+.btn-danger {
+    background: linear-gradient(135deg, #f87171, #ef4444);
+    border: none;
+    box-shadow: 0 16px 35px rgba(248, 113, 113, 0.28);
+}
+
+.btn-outline-primary {
+    border-color: rgba(56, 189, 248, 0.4);
+    color: var(--text-primary);
+}
+
+.btn-outline-primary:hover {
+    background: var(--accent-gradient);
+    border-color: transparent;
+}
+
+.btn-outline-light {
+    border-color: rgba(248, 250, 252, 0.35);
+    color: var(--text-primary);
+}
+
+.onboarding-buddy {
+    background: rgba(15, 23, 42, 0.68);
+    border-radius: 22px;
+    border: 1px solid var(--surface-border);
+    padding: 2rem;
+    backdrop-filter: blur(22px);
+    box-shadow: 0 26px 60px rgba(15, 23, 42, 0.55);
+    height: 100%;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.onboarding-buddy.celebrating {
+    border-color: rgba(52, 211, 153, 0.55);
+    box-shadow: 0 24px 70px rgba(52, 211, 153, 0.35);
+}
+
+.buddy-emoji {
+    font-size: 2.6rem;
+    margin-bottom: 1rem;
+}
+
+.buddy-title {
+    font-size: 1.45rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.buddy-message {
+    color: var(--text-muted);
+    margin-bottom: 1.25rem;
+}
+
+.buddy-checklist {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem;
+}
+
+.buddy-checklist li {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    color: var(--text-muted);
+    margin-bottom: 0.9rem;
+}
+
+.buddy-checklist li .icon {
+    color: var(--accent);
+    font-size: 1rem;
+    margin-top: 0.15rem;
+}
+
+.buddy-footer {
+    border-top: 1px solid var(--surface-border);
+    padding-top: 1rem;
+    color: var(--text-subtle);
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.dashboard-shell {
+    margin-top: 4rem;
+}
+
+.navigation-card {
+    background: rgba(15, 23, 42, 0.58);
+    border: 1px solid var(--surface-border);
+    border-radius: var(--card-radius);
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.5);
+}
+
+.dashboard-tabs .nav-link {
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--text-subtle);
+    padding: 0.75rem 1.5rem;
+    margin: 0.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    border: 1px solid transparent;
+    transition: all 0.25s ease;
+}
+
+.dashboard-tabs .nav-link i {
+    font-size: 1rem;
+}
+
+.dashboard-tabs .nav-link.active {
+    background: var(--accent-gradient);
+    color: #fff;
+    border-color: rgba(56, 189, 248, 0.45);
+    box-shadow: 0 16px 40px rgba(56, 189, 248, 0.35);
+}
+
+.dashboard-section {
+    margin-bottom: 2.5rem;
+}
+
+.section-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.section-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.section-subtitle {
+    font-size: 0.95rem;
+    color: var(--text-subtle);
+}
+
+.card {
+    background: rgba(15, 23, 42, 0.58);
+    border: 1px solid var(--surface-border);
+    border-radius: 20px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.5);
+    backdrop-filter: blur(18px);
+}
+
+.card-header {
+    background: rgba(15, 23, 42, 0.52);
+    border-bottom: 1px solid var(--surface-border);
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+}
+
+.status-card {
+    border-radius: 22px;
+}
+
+.status-overview {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.status-label {
+    letter-spacing: 0.08em;
+}
+
+.status-description {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.status-times {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    transition: transform 0.2s ease;
+    background: var(--surface-highlight);
+    color: var(--text-muted);
+}
+
+.status-badge.idle {
+    color: var(--text-muted);
+}
+
+.status-badge.scanning,
+.status-badge.verifying {
+    background: rgba(59, 130, 246, 0.2);
+    color: #60a5fa;
+}
+
+.status-badge.monitoring {
+    background: rgba(56, 189, 248, 0.2);
+    color: #67e8f9;
+}
+
+.status-badge.error {
+    background: rgba(248, 113, 113, 0.18);
+    color: var(--danger);
+}
+
+.status-badge.completed {
+    background: rgba(52, 211, 153, 0.18);
+    color: var(--success);
+}
+
+.progress {
+    background: rgba(148, 163, 184, 0.18);
+    border-radius: 999px;
+    height: 0.85rem;
+    overflow: hidden;
+}
+
+.progress-bar {
+    background: var(--accent-gradient);
+    font-weight: 600;
+}
+
+.progress-hint {
+    color: var(--text-subtle);
+}
+
+.stat-card {
+    display: flex;
+    align-items: center;
+    gap: 1.1rem;
+    padding: 1.4rem 1.6rem;
+    border-radius: 18px;
+    background: linear-gradient(150deg, rgba(56, 189, 248, 0.18), rgba(59, 130, 246, 0.1));
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.stat-card-icon {
+    width: 46px;
+    height: 46px;
+    border-radius: 16px;
+    background: rgba(148, 163, 184, 0.12);
+    color: var(--accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    flex-shrink: 0;
+}
+
+.stat-card-icon.accent {
+    background: rgba(56, 189, 248, 0.18);
+    color: var(--accent);
+}
+
+.stat-card-metric h1 {
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin-bottom: 0.2rem;
+}
+
+.stat-card-metric p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.stat-card.clickable {
+    cursor: pointer;
+}
+
+.stat-card.clickable:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 35px rgba(56, 189, 248, 0.25);
+}
+
+.empty-state {
+    display: flex;
+    align-items: center;
+    gap: 1.2rem;
+    padding: 1.5rem;
+    border-radius: 18px;
+    border: 1px dashed rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.52);
+}
+
+.empty-state-icon {
+    width: 46px;
+    height: 46px;
+    border-radius: 16px;
+    background: rgba(52, 211, 153, 0.18);
+    color: var(--success);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+}
+
+.changes-panel .card {
+    border-radius: 20px;
+}
+
+#collection-tabs.nav {
+    gap: 0.5rem;
+}
+
+#collection-tabs .nav-link {
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--text-subtle);
+    border: 1px solid transparent;
+    padding: 0.55rem 1.1rem;
+}
+
+#collection-tabs .nav-link.active {
+    background: var(--accent-gradient);
+    color: #fff;
+    border-color: rgba(56, 189, 248, 0.35);
+    box-shadow: 0 12px 30px rgba(56, 189, 248, 0.3);
+}
+
+.table {
+    color: var(--text-primary);
+    border-color: rgba(148, 163, 184, 0.2);
+}
+
+.table-striped > tbody > tr:nth-of-type(odd) > * {
+    background-color: rgba(15, 23, 42, 0.65);
+}
+
+.table thead th {
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.table-hover tbody tr:hover {
+    background: rgba(59, 130, 246, 0.12);
+}
+
+.toast {
+    background-color: rgba(15, 23, 42, 0.75);
+    border: 1px solid var(--surface-border);
+    color: var(--text-primary);
+    border-radius: 16px;
+}
+
+.toast-header {
+    border-bottom: 1px solid var(--surface-border);
+}
+
+.list-group-item {
+    background: rgba(15, 23, 42, 0.6);
+    border-color: rgba(148, 163, 184, 0.2);
+    color: var(--text-primary);
+}
+
+.alert {
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    color: var(--text-primary);
+}
+
+.alert-success {
+    background: rgba(34, 197, 94, 0.18);
+    border-color: rgba(34, 197, 94, 0.35);
+}
+
+.alert-danger {
+    background: rgba(248, 113, 113, 0.18);
+    border-color: rgba(248, 113, 113, 0.3);
+}
+
+.alert-info {
+    background: rgba(59, 130, 246, 0.18);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: #a5b4fc;
+}
+
+.modal-content {
+    background: rgba(15, 23, 42, 0.9);
+    border: 1px solid var(--surface-border);
+    border-radius: 20px;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.6);
+}
+
+.modal-header,
+.modal-footer {
+    border-color: rgba(148, 163, 184, 0.2);
+}
+
+.card.bg-dark {
+    background: rgba(15, 23, 42, 0.72) !important;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.action-panel .btn {
+    min-width: 150px;
+}
+
+.progress-container {
+    transition: opacity 0.3s ease;
+}
+
+#reports-table tr:hover {
+    background: rgba(56, 189, 248, 0.12);
+}
+
+.toast-container {
+    z-index: 1100;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 992px) {
+    .hero-surface {
+        padding: 2.25rem;
+    }
+
+    .wizard-shell {
+        padding: 2rem 1.5rem;
+    }
+
+    .navigation-card .card-body {
+        padding: 1.5rem 1rem;
+    }
+
+    .hero-metric-card {
+        padding: 1.1rem 1.2rem;
+    }
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 24px 0 60px;
+    }
+
+    .hero-surface {
+        padding: 2rem;
+    }
+
+    .hero-metric-card {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .hero-metric-icon {
+        width: 48px;
+        height: 48px;
+        border-radius: 14px;
+    }
+
+    .hero-metric-value {
+        font-size: 1.7rem;
+    }
+
+    .setup-progress {
+        padding-bottom: 1rem;
+    }
+
+    .setup-progress-step .step-circle {
+        width: 42px;
+        height: 42px;
+    }
+
+    .stat-card {
+        padding: 1.25rem 1.4rem;
+    }
+
+    .action-panel .btn {
+        width: 100%;
+        min-width: 0;
+    }
+}
+
+@media (max-width: 576px) {
+    .hero-surface {
+        padding: 1.8rem;
+    }
+
+    .hero-metric-grid {
+        margin-top: 1.2rem;
+    }
+
+    .hero-metric-card {
+        padding: 1rem 1.05rem;
+    }
+
+    .hero-metric-pills {
+        gap: 0.45rem;
+    }
+
+    .wizard-card .card-body {
+        padding: 1.5rem;
+    }
+
+    .hero-actions .btn {
+        width: 100%;
+    }
+
+    .navigation-card .nav-link {
+        width: 100%;
+        justify-content: center;
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,557 +5,397 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FELScanner</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <style>
-        :root {
-            --bs-body-bg: #121212;
-            --bs-body-color: #e0e0e0;
-            --card-bg: #1e1e1e;
-            --card-border: #333;
-            --input-bg: #2d2d2d;
-            --input-border: #444;
-            --input-color: #e0e0e0;
-            --stat-card-bg: #242424;
-            --stat-card-hover-bg: #2a2a2a;
-            --bg-color: #f8f9fa;
-            --text-color: #212529;
-            --card-border: #dee2e6;
-            --input-border: #ced4da;
-            --input-color: #212529;
-        }
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
 
-        [data-bs-theme="dark"] {
-            --bg-color: #212529;
-            --text-color: #f8f9fa;
-            --card-bg: #2c3034;
-            --card-border: #495057;
-            --stat-card-bg: #343a40;
-            --stat-card-hover-bg: #495057;
-            --input-bg: #343a40;
-            --input-border: #495057;
-            --input-color: #e9ecef;
-        }
-
-        body {
-            padding-top: 20px;
-            padding-bottom: 40px;
-            background-color: var(--bg-color);
-            color: var(--text-color);
-            font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif;
-        }
-        .container {
-            max-width: 960px;
-        }
-        .setup-step {
-            display: none;
-        }
-        .setup-step:first-child {
-            display: block;
-        }
-        .dashboard-section {
-            margin-bottom: 2rem;
-        }
-        .status-badge {
-            display: inline-block;
-            padding: 0.25rem 0.5rem;
-            border-radius: 0.25rem;
-            font-weight: bold;
-            text-transform: uppercase;
-        }
-        .status-badge.idle {
-            background-color: #2d3748;
-            color: #a0aec0;
-        }
-        .status-badge.scanning, .status-badge.verifying {
-            background-color: #1a365d;
-            color: #63b3ed;
-        }
-        .status-badge.monitoring {
-            background-color: #1c4532;
-            color: #68d391;
-        }
-        .status-badge.error {
-            background-color: #742a2a;
-            color: #fc8181;
-        }
-        .status-badge.completed {
-            background-color: #1c4532;
-            color: #68d391;
-        }
-        .form-section {
-            margin-bottom: 1.5rem;
-        }
-        .stat-card {
-            text-align: center;
-            padding: 1rem;
-            border-radius: 0.375rem;
-            background-color: var(--stat-card-bg);
-            margin-bottom: 1rem;
-            border: 1px solid var(--card-border);
-        }
-        .stat-card h1 {
-            font-size: 2.5rem;
-            font-weight: bold;
-            margin-bottom: 0.5rem;
-            color: #fff;
-        }
-        .stat-card p {
-            margin-bottom: 0;
-            color: #9ca3af;
-        }
-        .stat-card.clickable {
-            cursor: pointer;
-            position: relative;
-            overflow: hidden;
-        }
-        .stat-card.clickable:before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: rgba(255, 255, 255, 0.05);
-            opacity: 0;
-            transition: opacity 0.2s;
-        }
-        .stat-card.clickable:hover:before {
-            opacity: 1;
-        }
-        .scan-status-container {
-            border-radius: 0.375rem;
-            margin-bottom: 1rem;
-            padding: 1rem;
-            background-color: var(--card-bg);
-            border: 1px solid var(--card-border);
-        }
-        .scan-times {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1rem;
-            font-size: 0.875rem;
-            color: #9ca3af;
-        }
-        .scan-times > div {
-            flex: 1;
-            min-width: 200px;
-        }
-        .scan-actions {
-            display: flex;
-            gap: 0.5rem;
-            margin-top: 1rem;
-        }
-        .change-item {
-            padding: 0.75rem;
-            margin-bottom: 0.5rem;
-            border-radius: 0.25rem;
-            border-left: 3px solid;
-        }
-        .change-item.added {
-            background-color: rgba(52, 211, 153, 0.1);
-            border-left-color: #34d399;
-        }
-        .change-item.removed {
-            background-color: rgba(239, 68, 68, 0.1);
-            border-left-color: #ef4444;
-        }
-        .changes-tab-content {
-            padding-top: 1rem;
-        }
-        .changes-header {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 1rem;
-        }
-        .change-count {
-            font-size: 0.875rem;
-            color: #9ca3af;
-        }
-        .nav-link {
-            color: var(--bs-body-color);
-            opacity: 0.8;
-        }
-        .nav-link:hover,
-        .nav-link:focus {
-            color: var(--bs-body-color);
-            opacity: 1;
-        }
-        .nav-link.active {
-            color: #3182ce !important;
-            opacity: 1;
-        }
-        .card {
-            background-color: var(--card-bg);
-            border-color: var(--card-border);
-        }
-        .card-header {
-            background-color: rgba(0, 0, 0, 0.15);
-            border-bottom: 1px solid var(--card-border);
-        }
-        .stat-card {
-            box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.2);
-            transition: transform 0.2s;
-            background-color: var(--stat-card-bg);
-        }
-        .stat-card:hover {
-            transform: translateY(-3px);
-            background-color: var(--stat-card-hover-bg);
-        }
-        .form-control, .input-group-text {
-            background-color: var(--input-bg);
-            border-color: var(--input-border);
-            color: var(--input-color);
-        }
-        .form-control:focus {
-            background-color: var(--input-bg);
-            color: var(--input-color);
-        }
-        .form-check-input {
-            background-color: var(--input-bg);
-            border-color: var(--input-border);
-        }
-        .table {
-            color: var(--bs-body-color);
-            border-color: var(--card-border);
-        }
-        .alert-info {
-            background-color: #1a365d;
-            color: #63b3ed;
-            border-color: #2a4365;
-        }
-        .list-group-item {
-            background-color: var(--card-bg);
-            border-color: var(--card-border);
-            color: var(--bs-body-color);
-        }
-        .form-text {
-            color: #9ca3af;
-        }
-        
-        /* Toast styling */
-        .toast {
-            background-color: var(--card-bg);
-            border: 1px solid var(--card-border);
-            color: var(--text-color);
-        }
-        .toast-header {
-            border-bottom: 1px solid var(--card-border);
-        }
-        .toast-container {
-            z-index: 1100;
-        }
-        
-        /* Sorting styles */
-        .sortable {
-            cursor: pointer;
-            position: relative;
-            padding-right: 25px; /* Add space for sort icon */
-        }
-        .sortable:hover {
-            background-color: rgba(128, 128, 128, 0.1);
-        }
-        .sortable .fa-sort {
-            position: absolute;
-            right: 8px;
-            top: 50%;
-            transform: translateY(-50%);
-            opacity: 0.4;
-        }
-        .sortable .fa-sort-up,
-        .sortable .fa-sort-down {
-            position: absolute;
-            right: 8px;
-            top: 50%;
-            transform: translateY(-50%);
-            opacity: 1;
-            color: #3182ce; /* Bright blue color for sort indicators */
-        }
-        .sortable.sort-asc .fa-sort,
-        .sortable.sort-desc .fa-sort {
-            display: none;
-        }
-        .sort-asc, .sort-desc {
-            font-weight: bold;
-            color: #3182ce;
-        }
-        /* Hide columns when needed */
-        .size-col {
-            display: table-cell;
-        }
-        .alert {
-            padding: 10px;
-            margin-bottom: 15px;
-            border-radius: 4px;
-        }
-        .loading-spinner {
-            display: inline-block;
-            width: 1rem;
-            height: 1rem;
-            margin-right: 5px;
-            border: 0.15em solid currentColor;
-            border-right-color: transparent;
-            border-radius: 50%;
-            -webkit-animation: spinner-border .75s linear infinite;
-            animation: spinner-border .75s linear infinite;
-            vertical-align: middle;
-        }
-        /* Table styling */
-        .table th.sortable {
-            cursor: pointer;
-            position: relative;
-        }
-        .table th.sortable:hover {
-            background-color: rgba(0,0,0,0.05);
-        }
-        .table th.sort-asc::after {
-            content: "▲";
-            position: absolute;
-            right: 8px;
-            color: #007bff;
-        }
-        .table th.sort-desc::after {
-            content: "▼";
-            position: absolute;
-            right: 8px;
-            color: #007bff;
-        }
-        /* Custom column widths for movie table */
-        .year-col {
-            width: 70px;
-        }
-        .dv-profile-col {
-            width: 90px;
-        }
-        .audio-col {
-            width: 150px;
-        }
-        .bitrate-col {
-            width: 90px;
-        }
-    </style>
 </head>
 <body>
     <div class="container">
-        <header class="mb-4">
-            <h1 class="text-center">FELScanner</h1>
-            <p class="text-center text-muted">Scan your Plex library for Dolby Vision and TrueHD Atmos content</p>
-        </header>
-        
-        <!-- Setup Wizard -->
-        <div id="setup-wizard" style="display: {% if setup_completed %}none{% else %}block{% endif %};">
-            <div class="card">
-                <div class="card-header">
-                    <h5>Setup Wizard</h5>
+        <header class="hero-surface mb-5">
+            <div class="row align-items-center g-4">
+                <div class="col-lg-7">
+                    <span class="hero-badge"><i class="fas fa-bolt"></i> Library intelligence</span>
+                    <h1 class="hero-title">FELScanner Control Center</h1>
+                    <p class="hero-subtitle">Orchestrate Dolby Vision, Profile 7 FEL, and TrueHD Atmos workflows from a single beautiful command center.</p>
+                    <div class="hero-actions d-flex flex-wrap gap-3">
+                        <a class="btn btn-primary btn-lg px-4" href="#setup-anchor">Start guided setup</a>
+                        <a class="btn btn-outline-light btn-lg px-4" href="#main-dashboard">Jump to dashboard</a>
+                    </div>
+                    <p class="hero-footnote text-muted mt-4 mb-0">Need help later? Our onboarding buddy keeps contextual tips at your fingertips.</p>
+                    <div class="hero-metric-grid row g-3 mt-4" role="group" aria-label="Library snapshot">
+                        <div class="col-sm-4">
+                            <div class="hero-metric-card">
+                                <div class="hero-metric-icon"><i class="fas fa-database"></i></div>
+                                <div>
+                                    <p class="hero-metric-label">Titles indexed</p>
+                                    <p class="hero-metric-value" id="hero-total-metric" aria-live="polite">0</p>
+                                    <p class="hero-metric-caption">Movies tracked across Plex</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="hero-metric-card accent">
+                                <div class="hero-metric-icon"><i class="fas fa-mountain"></i></div>
+                                <div>
+                                    <p class="hero-metric-label">High-fidelity stack</p>
+                                    <div class="hero-metric-pills" aria-live="polite">
+                                        <span class="metric-pill" id="hero-dv-pill"><span class="metric-pill-label">DV</span><span class="metric-pill-value" id="hero-dv-metric">0</span></span>
+                                        <span class="metric-pill" id="hero-p7-pill"><span class="metric-pill-label">P7 FEL</span><span class="metric-pill-value" id="hero-p7-metric">0</span></span>
+                                        <span class="metric-pill" id="hero-atmos-pill"><span class="metric-pill-label">Atmos</span><span class="metric-pill-value" id="hero-atmos-metric">0</span></span>
+                                    </div>
+                                    <p class="hero-metric-caption">Live counts for premium formats</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="hero-metric-card status" aria-live="polite">
+                                <div class="hero-metric-icon"><i class="fas fa-satellite-dish"></i></div>
+                                <div class="hero-status-copy">
+                                    <p class="hero-metric-label">Automation</p>
+                                    <span id="hero-monitor-status" class="hero-status-chip idle" aria-live="polite">Idle</span>
+                                    <p class="hero-metric-caption mb-1" id="hero-monitor-caption">Waiting for the first scan</p>
+                                    <p class="hero-metric-subtle" id="hero-monitor-subcaption">No schedule yet</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-                <div class="card-body">
-                    <!-- Step 1: Plex Connection -->
-                    <div class="setup-step">
-                        <h4>Step 1: Plex Connection</h4>
-                        <p>Enter your Plex server details to connect to your library.</p>
-                        
-                        <div class="mb-3">
-                            <label for="plex-url" class="form-label">Plex URL</label>
-                            <input type="text" class="form-control" id="plex-url" placeholder="http://localhost:32400">
-                            <div class="form-text">The URL to your Plex server, including port (usually 32400)</div>
-                        </div>
-                        
-                        <div class="mb-3">
-                            <label for="plex-token" class="form-label">Plex Token</label>
-                            <input type="text" class="form-control" id="plex-token" placeholder="Your Plex authentication token">
-                            <div class="form-text">Your Plex authentication token <a href="https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/" target="_blank">How to find your token</a></div>
-                        </div>
-                        
-                        <div class="mb-3">
-                            <label for="library-name" class="form-label">Movie Library Name</label>
-                            <input type="text" class="form-control" id="library-name" placeholder="Movies">
-                            <div class="form-text">The exact name of your movie library in Plex</div>
-                        </div>
-                        
-                        <div class="alert alert-success" id="plex-success" style="display: none;"></div>
-                        <div class="alert alert-danger" id="plex-error" style="display: none;"></div>
-                        
-                        <div class="mt-3">
-                            <button type="button" class="btn btn-primary" id="test-plex-btn">Test Connection</button>
-                            <button type="button" class="btn btn-success next-step" style="display: none;">Next</button>
-                        </div>
-                    </div>
-                    
-                    <!-- Step 2: Collection Settings -->
-                    <div class="setup-step">
-                        <h4>Step 2: Collection Settings</h4>
-                        <p>Configure the collection names for different content types.</p>
-                        
-                        <div class="mb-3">
-                            <label for="collection-dv" class="form-label">Dolby Vision Collection</label>
-                            <input type="text" class="form-control" id="collection-dv" value="All Dolby Vision">
-                            <div class="form-text">Name for the collection containing all Dolby Vision content</div>
-                        </div>
-                        
-                        <div class="mb-3">
-                            <label for="collection-p7" class="form-label">Profile 7 FEL Collection</label>
-                            <input type="text" class="form-control" id="collection-p7" value="DV FEL Profile 7">
-                            <div class="form-text">Name for the collection containing Profile 7 FEL content</div>
-                        </div>
-                        
-                        <div class="mb-3">
-                            <label for="collection-atmos" class="form-label">TrueHD Atmos Collection</label>
-                            <input type="text" class="form-control" id="collection-atmos" value="TrueHD Atmos">
-                            <div class="form-text">Name for the collection containing TrueHD Atmos audio</div>
-                        </div>
-                        
-                        <div class="mb-3">
-                            <label for="reports-size" class="form-label">Maximum Report Storage (MB)</label>
-                            <input type="number" class="form-control" id="reports-size" value="5" min="1">
-                            <div class="form-text">Maximum disk space to use for storing reports (in MB)</div>
-                        </div>
-                        
-                        <div class="mt-3">
-                            <button type="button" class="btn btn-secondary prev-step">Previous</button>
-                            <button type="button" class="btn btn-success next-step">Next</button>
-                        </div>
-                    </div>
-                    
-                    <!-- Step 3: Notifications -->
-                    <div class="setup-step">
-                        <h4>Step 3: Notifications (Optional)</h4>
-                        <p>Configure Telegram notifications for updates.</p>
-                        
-                        <div class="form-check mb-3">
-                            <input class="form-check-input" type="checkbox" id="telegram-enabled">
-                            <label class="form-check-label" for="telegram-enabled">
-                                Enable Telegram notifications
-                            </label>
-                        </div>
-                        
-                        <div id="telegram-settings" style="display: none;">
-                            <div class="mb-3">
-                                <label for="telegram-token" class="form-label">Bot Token</label>
-                                <input type="text" class="form-control" id="telegram-token">
-                                <div class="form-text">Your Telegram bot token from BotFather</div>
-                            </div>
-                            
-                            <div class="mb-3">
-                                <label for="telegram-chat-id" class="form-label">Chat ID</label>
-                                <input type="text" class="form-control" id="telegram-chat-id">
-                                <div class="form-text">Your Telegram chat ID or group ID</div>
-                            </div>
-                            
-                            <div class="alert alert-success" id="telegram-success" style="display: none;"></div>
-                            <div class="alert alert-danger" id="telegram-error" style="display: none;"></div>
-                            
-                            <div class="mb-3">
-                                <button type="button" class="btn btn-primary" id="test-telegram-btn">Test Telegram</button>
-                            </div>
-                        </div>
-                        
-                        <div class="mt-3">
-                            <button type="button" class="btn btn-secondary prev-step">Previous</button>
-                            <button type="button" class="btn btn-success next-step">Complete Setup</button>
+                <div class="col-lg-5">
+                    <div class="hero-summary card h-100 position-relative overflow-hidden">
+                        <div class="card-body">
+                            <h5 class="text-uppercase small fw-semibold text-secondary mb-3">Your onboarding playbook</h5>
+                            <ul class="hero-checklist list-unstyled mb-0">
+                                <li><i class="fas fa-check-circle"></i><span>Connect securely to Plex</span></li>
+                                <li><i class="fas fa-check-circle"></i><span>Curate Dolby Vision collections</span></li>
+                                <li><i class="fas fa-check-circle"></i><span>Automate IPTorrents monitoring</span></li>
+                            </ul>
                         </div>
                     </div>
                 </div>
             </div>
+        </header>
+
+        <!-- Setup Wizard -->
+        <section id="setup-anchor" class="mb-5">
+        <div id="setup-wizard" class="wizard-shell" style="display: {% if setup_completed %}none{% else %}block{% endif %};">
+            <div class="row g-4 align-items-start">
+                <div class="col-lg-8">
+                    <div class="card wizard-card h-100">
+                        <div class="card-body">
+                            <div class="wizard-header d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
+                                <div>
+                                    <span class="wizard-kicker">Guided onboarding</span>
+                                    <h3 class="wizard-title">Let's prepare your library</h3>
+                                    <p class="wizard-subtitle mb-0">FELScanner will connect to Plex, organize collections, and configure notifications in just a few steps.</p>
+                                </div>
+                            </div>
+                            <div class="setup-progress">
+                                <div class="setup-progress-track"></div>
+                                <div class="setup-progress-fill" id="setup-progress-fill"></div>
+                                <div class="setup-progress-steps">
+                                    <button type="button" class="setup-progress-step active" data-step-index="0">
+                                        <span class="step-circle"><i class="fas fa-plug"></i></span>
+                                        <span class="step-label">Connect</span>
+                                        <span class="step-caption">Server access</span>
+                                    </button>
+                                    <button type="button" class="setup-progress-step" data-step-index="1">
+                                        <span class="step-circle"><i class="fas fa-layer-group"></i></span>
+                                        <span class="step-label">Collections</span>
+                                        <span class="step-caption">Naming &amp; reports</span>
+                                    </button>
+                                    <button type="button" class="setup-progress-step" data-step-index="2">
+                                        <span class="step-circle"><i class="fas fa-bell"></i></span>
+                                        <span class="step-label">Notifications</span>
+                                        <span class="step-caption">Optional alerts</span>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="setup-steps">
+                                <div class="setup-step active" data-step-index="0" data-step-key="connect">
+                                    <div class="step-header">
+                                        <div class="step-icon"><i class="fas fa-plug"></i></div>
+                                        <div>
+                                            <h4 class="step-title">Step 1 — Plex connection</h4>
+                                            <p class="step-description">Enter your Plex server details to connect to your library.</p>
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="plex-url" class="form-label">Plex URL</label>
+                                        <input type="text" class="form-control" id="plex-url" placeholder="http://localhost:32400">
+                                        <div class="form-text">The URL to your Plex server, including port (usually 32400)</div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="plex-token" class="form-label">Plex Token</label>
+                                        <input type="text" class="form-control" id="plex-token" placeholder="Your Plex authentication token">
+                                        <div class="form-text">Your Plex authentication token <a href="https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/" target="_blank">How to find your token</a></div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="library-name" class="form-label">Movie Library Name</label>
+                                        <input type="text" class="form-control" id="library-name" placeholder="Movies">
+                                        <div class="form-text">The exact name of your movie library in Plex</div>
+                                    </div>
+
+                                    <div class="alert alert-success" id="plex-success" style="display: none;"></div>
+                                    <div class="alert alert-danger" id="plex-error" style="display: none;"></div>
+
+                                    <div class="d-flex flex-wrap gap-2 mt-3">
+                                        <button type="button" class="btn btn-primary" id="test-plex-btn">Test connection</button>
+                                        <button type="button" class="btn btn-success next-step" style="display: none;">Continue</button>
+                                    </div>
+                                </div>
+
+                                <div class="setup-step" data-step-index="1" data-step-key="collections">
+                                    <div class="step-header">
+                                        <div class="step-icon"><i class="fas fa-layer-group"></i></div>
+                                        <div>
+                                            <h4 class="step-title">Step 2 — Collection preferences</h4>
+                                            <p class="step-description">Configure how FELScanner curates your Dolby Vision, Profile 7 FEL, and Atmos collections.</p>
+                                        </div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="collection-dv" class="form-label">Dolby Vision collection</label>
+                                        <input type="text" class="form-control" id="collection-dv" value="All Dolby Vision">
+                                        <div class="form-text">Name for the collection containing all Dolby Vision content</div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="collection-p7" class="form-label">Profile 7 FEL collection</label>
+                                        <input type="text" class="form-control" id="collection-p7" value="DV FEL Profile 7">
+                                        <div class="form-text">Name for the collection containing Profile 7 FEL content</div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="collection-atmos" class="form-label">TrueHD Atmos collection</label>
+                                        <input type="text" class="form-control" id="collection-atmos" value="TrueHD Atmos">
+                                        <div class="form-text">Name for the collection containing TrueHD Atmos audio</div>
+                                    </div>
+
+                                    <div class="mb-3">
+                                        <label for="reports-size" class="form-label">Maximum report storage (MB)</label>
+                                        <input type="number" class="form-control" id="reports-size" value="5" min="1">
+                                        <div class="form-text">Maximum disk space to use for storing reports (in MB)</div>
+                                    </div>
+
+                                    <div class="d-flex flex-wrap gap-2 mt-3">
+                                        <button type="button" class="btn btn-secondary prev-step">Back</button>
+                                        <button type="button" class="btn btn-success next-step">Continue</button>
+                                    </div>
+                                </div>
+
+                                <div class="setup-step" data-step-index="2" data-step-key="notifications">
+                                    <div class="step-header">
+                                        <div class="step-icon"><i class="fas fa-bell"></i></div>
+                                        <div>
+                                            <h4 class="step-title">Step 3 — Notifications (optional)</h4>
+                                            <p class="step-description">Configure Telegram notifications for library updates.</p>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-check mb-3">
+                                        <input class="form-check-input" type="checkbox" id="telegram-enabled">
+                                        <label class="form-check-label" for="telegram-enabled">Enable Telegram notifications</label>
+                                    </div>
+
+                                    <div id="telegram-settings" style="display: none;">
+                                        <div class="mb-3">
+                                            <label for="telegram-token" class="form-label">Bot token</label>
+                                            <input type="text" class="form-control" id="telegram-token">
+                                            <div class="form-text">Your Telegram bot token from BotFather</div>
+                                        </div>
+
+                                        <div class="mb-3">
+                                            <label for="telegram-chat-id" class="form-label">Chat ID</label>
+                                            <input type="text" class="form-control" id="telegram-chat-id">
+                                            <div class="form-text">Your Telegram chat ID or group ID</div>
+                                        </div>
+
+                                        <div class="alert alert-success" id="telegram-success" style="display: none;"></div>
+                                        <div class="alert alert-danger" id="telegram-error" style="display: none;"></div>
+
+                                        <div class="mb-3">
+                                            <button type="button" class="btn btn-primary" id="test-telegram-btn">Test Telegram</button>
+                                        </div>
+                                    </div>
+
+                                    <div class="d-flex flex-wrap gap-2 mt-3">
+                                        <button type="button" class="btn btn-secondary prev-step">Back</button>
+                                        <button type="button" class="btn btn-success next-step">Complete setup</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-4">
+                    <aside class="onboarding-buddy h-100" id="onboarding-buddy">
+                        <div class="buddy-emoji" id="buddy-emoji">👋</div>
+                        <h4 class="buddy-title" id="buddy-title">Welcome!</h4>
+                        <p class="buddy-message" id="buddy-message">Let's connect to Plex to get started.</p>
+                        <ul class="buddy-checklist" id="buddy-checklist"></ul>
+                        <div class="buddy-footer">
+                            <i class="fas fa-lightbulb me-2"></i>
+                            <span id="buddy-footer-text">I'll keep track of progress and surface helpful reminders.</span>
+                        </div>
+                    </aside>
+                </div>
+            </div>
         </div>
-        
+    </section>
+
         <!-- Main Dashboard -->
-        <div id="main-dashboard" style="display: {% if setup_completed %}block{% else %}none{% endif %};">
-            <ul class="nav nav-tabs mb-4" id="dashboard-tabs" role="tablist">
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link active" id="home-tab" data-bs-toggle="tab" data-bs-target="#home" type="button" role="tab" aria-controls="home" aria-selected="true">Dashboard</button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="reports-tab" data-bs-toggle="tab" data-bs-target="#reports" type="button" role="tab" aria-controls="reports" aria-selected="false">Reports</button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="iptscanner-tab" data-bs-toggle="tab" data-bs-target="#iptscanner" type="button" role="tab" aria-controls="iptscanner" aria-selected="false">IPTScanner</button>
-                </li>
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">Settings</button>
-                </li>
-            </ul>
-            
+        <div id="main-dashboard" class="dashboard-shell" style="display: {% if setup_completed %}block{% else %}none{% endif %};">
+            <div class="card navigation-card mb-4">
+                <div class="card-body py-3 px-2 px-md-3">
+                    <ul class="nav nav-pills dashboard-tabs flex-wrap" id="dashboard-tabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" id="home-tab" data-bs-toggle="tab" data-bs-target="#home" type="button" role="tab" aria-controls="home" aria-selected="true">
+                                <i class="fas fa-chart-line"></i><span>Dashboard</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="reports-tab" data-bs-toggle="tab" data-bs-target="#reports" type="button" role="tab" aria-controls="reports" aria-selected="false">
+                                <i class="fas fa-file-alt"></i><span>Reports</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="iptscanner-tab" data-bs-toggle="tab" data-bs-target="#iptscanner" type="button" role="tab" aria-controls="iptscanner" aria-selected="false">
+                                <i class="fas fa-magnet"></i><span>IPTScanner</span>
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button" role="tab" aria-controls="settings" aria-selected="false">
+                                <i class="fas fa-sliders-h"></i><span>Settings</span>
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
             <div class="tab-content">
                 <!-- Home Tab -->
                 <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
                     <!-- Status Section -->
                     <div class="dashboard-section">
-                        <h4>Status</h4>
-                        <div class="card">
+                        <div class="section-heading d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3">
+                            <div>
+                                <h4 class="section-title mb-1">Status</h4>
+                                <p class="section-subtitle mb-0 text-muted">Track scans, automation, and library health at a glance.</p>
+                            </div>
+                            <div class="status-meta-small d-none d-md-flex align-items-center gap-3">
+                                <span class="small text-muted"><i class="fas fa-history me-2"></i>Last scan <span id="last-scan-time">Never</span></span>
+                                <span class="small text-muted" id="next-scan-container" style="display: none;"><i class="fas fa-clock me-2"></i>Next scan <span id="next-scan-time">Unknown</span></span>
+                            </div>
+                        </div>
+                        <div class="card status-card">
                             <div class="card-body">
-                                <div class="row">
-                                    <div class="col-md-6">
-                                        <p>Current Status: <span id="status-badge" class="status-badge idle">Idle</span></p>
-                                        <p>Last Scan: <span id="last-scan-time">Never</span></p>
-                                        <div id="next-scan-container" style="display: none;">
-                                            <p>Next Scan: <span id="next-scan-time">Unknown</span></p>
+                                <div class="row g-4 align-items-center">
+                                    <div class="col-lg-7">
+                                        <div class="status-overview">
+                                            <span class="status-label text-uppercase small fw-semibold text-muted">Current status</span>
+                                            <div class="d-flex align-items-center gap-3 mt-3">
+                                                <span id="status-badge" class="status-badge idle">Idle</span>
+                                                <div class="status-times d-flex flex-column gap-2 d-lg-none">
+                                                    <span class="text-muted small"><i class="fas fa-history me-2"></i>Last scan <span id="last-scan-time-mobile">Never</span></span>
+                                                    <span class="text-muted small" id="next-scan-container-mobile" style="display: none;"><i class="fas fa-clock me-2"></i>Next scan <span id="next-scan-time-mobile">Unknown</span></span>
+                                                </div>
+                                            </div>
+                                            <p class="status-description text-muted mt-3 mb-0">Launch a manual scan, verify collections, or toggle monitoring right from here.</p>
                                         </div>
                                     </div>
-                                    <div class="col-md-6 text-end">
-                                        <div class="d-grid gap-2 d-md-flex justify-content-md-end action-buttons">
-                                            <button id="start-scan-btn" class="btn btn-primary me-md-2 mb-2">Start Scan</button>
-                                            <button id="verify-collections-btn" class="btn btn-secondary me-md-2 mb-2">Verify Collections</button>
-                                            <button id="start-monitor-btn" class="btn btn-success mb-2">Start Monitor</button>
-                                            <button id="stop-monitor-btn" class="btn btn-danger mb-2" style="display: none;">Stop Monitor</button>
+                                    <div class="col-lg-5">
+                                        <div class="action-panel d-flex flex-wrap gap-2 justify-content-lg-end">
+                                            <button id="start-scan-btn" class="btn btn-primary">Start Scan</button>
+                                            <button id="verify-collections-btn" class="btn btn-secondary">Verify Collections</button>
+                                            <button id="start-monitor-btn" class="btn btn-success">Start Monitor</button>
+                                            <button id="stop-monitor-btn" class="btn btn-danger" style="display: none;">Stop Monitor</button>
                                         </div>
                                     </div>
                                 </div>
-                                
-                                <div id="scan-progress-container" class="progress-container" style="display: none;">
+                                <div id="scan-progress-container" class="progress-container mt-4" style="display: none;">
                                     <div class="progress">
                                         <div id="scan-progress" class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">0%</div>
                                     </div>
+                                    <p class="progress-hint text-muted small mt-2 mb-0"><i class="fas fa-info-circle me-2"></i>Real-time updates arrive every few seconds.</p>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
+
                     <!-- Statistics Section -->
                     <div class="dashboard-section">
-                        <h4>Statistics</h4>
-                        <div class="row">
-                            <div class="col-md-3">
+                        <div class="section-heading d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3">
+                            <div>
+                                <h4 class="section-title mb-1">Library composition</h4>
+                                <p class="section-subtitle mb-0 text-muted">Tap a card to explore the titles that power each metric.</p>
+                            </div>
+                        </div>
+                        <div class="row g-3 g-lg-4">
+                            <div class="col-12 col-sm-6 col-lg-3">
                                 <div class="stat-card">
-                                    <h1 id="total-movies">0</h1>
-                                    <p>Total Movies</p>
+                                    <div class="stat-card-icon"><i class="fas fa-film"></i></div>
+                                    <div class="stat-card-metric">
+                                        <h1 id="total-movies">0</h1>
+                                        <p>Total Movies</p>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-12 col-sm-6 col-lg-3">
                                 <div class="stat-card clickable" data-collection="dv">
-                                    <h1 id="dv-movies">0</h1>
-                                    <p>Dolby Vision</p>
+                                    <div class="stat-card-icon accent"><i class="fas fa-bolt"></i></div>
+                                    <div class="stat-card-metric">
+                                        <h1 id="dv-movies">0</h1>
+                                        <p>Dolby Vision</p>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-12 col-sm-6 col-lg-3">
                                 <div class="stat-card clickable" data-collection="p7">
-                                    <h1 id="p7-movies">0</h1>
-                                    <p>Profile 7 FEL</p>
+                                    <div class="stat-card-icon accent"><i class="fas fa-layer-group"></i></div>
+                                    <div class="stat-card-metric">
+                                        <h1 id="p7-movies">0</h1>
+                                        <p>Profile 7 FEL</p>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-12 col-sm-6 col-lg-3">
                                 <div class="stat-card clickable" data-collection="atmos">
-                                    <h1 id="atmos-movies">0</h1>
-                                    <p>TrueHD Atmos</p>
+                                    <div class="stat-card-icon accent"><i class="fas fa-headphones"></i></div>
+                                    <div class="stat-card-metric">
+                                        <h1 id="atmos-movies">0</h1>
+                                        <p>TrueHD Atmos</p>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
+
                     <!-- Collection Changes Section -->
                     <div class="dashboard-section">
-                        <h4>Collection Changes</h4>
-                        <div id="no-changes-alert" class="alert alert-info">
-                            <i class="fas fa-info-circle"></i> No recent changes to collections. 
-                            <small>This means all movies are already properly categorized in their respective collections.</small>
+                        <div class="section-heading d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3">
+                            <div>
+                                <h4 class="section-title mb-1">Collection changes</h4>
+                                <p class="section-subtitle mb-0 text-muted">Monitor which titles moved in or out of your Dolby Vision, Profile 7, and Atmos collections.</p>
+                            </div>
                         </div>
-                        
-                        <div id="changes-container" class="mt-4" style="display: none;">
+                        <div id="no-changes-alert" class="empty-state">
+                            <div class="empty-state-icon"><i class="fas fa-check-circle"></i></div>
+                            <div>
+                                <h5 class="mb-1">Everything is in harmony</h5>
+                                <p class="text-muted mb-0">No recent additions or removals were detected. Your collections match the latest scan.</p>
+                            </div>
+                        </div>
+
+                        <div id="changes-container" class="changes-panel mt-4" style="display: none;">
                             <div class="card">
-                                <div class="card-header">
-                                    <h5>Collection Changes</h5>
-                                </div>
                                 <div class="card-body">
-                                    <div id="collection-tabs" class="nav nav-tabs mb-3">
+                                    <div id="collection-tabs" class="nav nav-pills mb-3">
                                         <!-- Tabs will be inserted here by JavaScript -->
                                     </div>
                                     <div id="collection-contents">
@@ -565,55 +405,62 @@
                             </div>
                         </div>
                     </div>
-                </div>
-                
+
                 <!-- Reports Tab -->
                 <div class="tab-pane fade" id="reports" role="tabpanel" aria-labelledby="reports-tab">
-                    <h4>Scan Reports</h4>
-                    <div class="card">
-                        <div class="card-body">
-                            <div class="table-responsive">
-                                <table class="table table-striped">
-                                    <thead>
-                                        <tr>
-                                            <th>Date</th>
-                                            <th>Filename</th>
-                                            <th>Size</th>
-                                            <th>Actions</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody id="reports-table">
-                                        <tr>
-                                            <td colspan="4" class="text-center">Loading reports...</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
+                    <div class="dashboard-section">
+                        <div class="section-heading d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3">
+                            <div>
+                                <h4 class="section-title mb-1">Scan reports</h4>
+                                <p class="section-subtitle mb-0 text-muted">Download or review your recent FELScanner exports.</p>
                             </div>
                             <button id="view-all-reports" class="btn btn-outline-primary">View All Reports</button>
                         </div>
-                    </div>
-                </div>
-                
-                <!-- IPTScanner Tab -->
-                <div class="tab-pane fade" id="iptscanner" role="tabpanel" aria-labelledby="iptscanner-tab">
-                    <h4>IPTorrents Monitor</h4>
-                    
-                    <div class="dashboard-section">
                         <div class="card">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h5 class="mb-0">Torrent Finder</h5>
-                                <div>
-                                    <button id="iptscanner-refresh" class="btn btn-primary btn-sm">
-                                        <i class="fas fa-sync-alt"></i> Refresh
-                                    </button>
+                            <div class="card-body">
+                                <div class="table-responsive">
+                                    <table class="table table-striped">
+                                        <thead>
+                                            <tr>
+                                                <th>Date</th>
+                                                <th>Filename</th>
+                                                <th>Size</th>
+                                                <th>Actions</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="reports-table">
+                                            <tr>
+                                                <td colspan="4" class="text-center">Loading reports...</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
                                 </div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- IPTScanner Tab -->
+                <div class="tab-pane fade" id="iptscanner" role="tabpanel" aria-labelledby="iptscanner-tab">
+                    <div class="dashboard-section">
+                        <div class="section-heading d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3">
+                            <div>
+                                <h4 class="section-title mb-1">IPTorrents monitor</h4>
+                                <p class="section-subtitle mb-0 text-muted">Review the latest searches and automate torrent discovery.</p>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <button id="iptscanner-refresh" class="btn btn-primary btn-sm">
+                                    <i class="fas fa-sync-alt"></i> Refresh
+                                </button>
+                            </div>
+                        </div>
+                        <div class="card">
                             <div class="card-body">
-                                <div class="row mb-3">
+                                <div class="row g-3 mb-3">
                                     <div class="col-md-4">
                                         <div class="card bg-dark">
                                             <div class="card-body">
-                                                <h6>Search Term</h6>
+                                                <h6>Search term</h6>
                                                 <p id="ipt-search-term" class="mb-0 text-info">Loading...</p>
                                             </div>
                                         </div>
@@ -621,7 +468,7 @@
                                     <div class="col-md-4">
                                         <div class="card bg-dark">
                                             <div class="card-body">
-                                                <h6>Last Check</h6>
+                                                <h6>Last check</h6>
                                                 <p id="ipt-last-check" class="mb-0 text-info">Loading...</p>
                                             </div>
                                         </div>
@@ -642,7 +489,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                
+
                                 <div class="table-responsive">
                                     <table class="table table-hover">
                                         <thead>
@@ -662,16 +509,21 @@
                                         </tbody>
                                     </table>
                                 </div>
-                                
-                                <div id="ipt-no-torrents" class="alert alert-info" style="display:none;">
+
+                                <div id="ipt-no-torrents" class="alert alert-info mt-3" style="display:none;">
                                     <i class="fas fa-info-circle"></i> No torrents found matching your search criteria.
                                 </div>
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="dashboard-section">
-                        <h5>Activity Log</h5>
+                        <div class="section-heading mb-3">
+                            <div>
+                                <h5 class="section-title mb-1">Activity log</h5>
+                                <p class="section-subtitle mb-0 text-muted">Inspect recent IPT scanner actions and status updates.</p>
+                            </div>
+                        </div>
                         <div class="card">
                             <div class="card-body">
                                 <div id="ipt-log" class="bg-dark p-3 rounded" style="max-height: 200px; overflow-y: auto;">
@@ -681,7 +533,7 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <!-- Settings Tab -->
                 <div class="tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
                     <h4>Settings</h4>


### PR DESCRIPTION
## Summary
- replace the inline styles with a dedicated dashboard stylesheet and restyle the entire interface with a modern hero, cards, and empty states
- restructure the index template to add the onboarding buddy, progress tracker, refreshed statistics, and polished reports/IPT sections
- enhance the front-end logic to drive the new stepper, contextual helper copy, and responsive status updates for mobile and desktop views

## Testing
- python -m compileall app.py scanner.py

------
https://chatgpt.com/codex/tasks/task_e_68e45d5585bc83218f108c0a4ed91a3f