### PR TITLE
Add Radarr release search with IPT filtering

### DIFF
--- a/app.py
+++ b/app.py
@@ -2985,13 +2985,6 @@ if app.config['SETUP_COMPLETED'] and app.config['AUTO_START_MODE'] == 'monitor':
 # New initialization approach
 init_iptscanner()
 
-# Add this at the bottom of the file, before app.run()
-if __name__ == "__main__":
-    # Initialize IPTScanner
-    init_iptscanner()
-    
-    # Start the app
-    app.run(host='0.0.0.0', port=5000, debug=True)
 
 @app.route('/api/iptscanner/test-run', methods=['POST'])
 def test_run_iptscanner():
@@ -3039,3 +3032,12 @@ def test_run_iptscanner():
     except Exception as e:
         app.logger.error(f"Error in test_run_iptscanner: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
+
+
+# Add this at the bottom of the file, before app.run()
+if __name__ == "__main__":
+    # Initialize IPTScanner
+    init_iptscanner()
+
+    # Start the app
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/integrations/radarr.py
+++ b/integrations/radarr.py
@@ -1,0 +1,157 @@
+import logging
+import threading
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+log = logging.getLogger(__name__)
+
+
+class RadarrClient:
+    """Async helper for interacting with Radarr's API"""
+
+    def __init__(self, base_url: str, api_key: str, *, timeout: int = 30):
+        self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
+        self.timeout = timeout
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._session_lock = threading.Lock()
+        self._is_closing = False
+
+    async def _ensure_session(self) -> None:
+        if self._is_closing:
+            raise RuntimeError("Radarr client is closing")
+
+        if self._session and not self._session.closed:
+            return
+
+        with self._session_lock:
+            if self._session and not self._session.closed:
+                return
+
+            connector = aiohttp.TCPConnector(limit=10, limit_per_host=5, ttl_dns_cache=300)
+            headers = {
+                "X-Api-Key": self.api_key,
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+
+            self._session = aiohttp.ClientSession(
+                connector=connector,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=self.timeout),
+            )
+
+    async def close(self) -> None:
+        self._is_closing = True
+        if self._session and not self._session.closed:
+            try:
+                await self._session.close()
+            except Exception as exc:  # pragma: no cover - best effort close
+                log.debug("Error closing Radarr session: %s", exc)
+            finally:
+                self._session = None
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Any] = None,
+    ) -> Any:
+        await self._ensure_session()
+        assert self._session is not None
+
+        url = f"{self.base_url}{path}"
+
+        async with self._session.request(method, url, params=params, json=json_body) as response:
+            if response.status >= 400:
+                text = await response.text()
+                raise RuntimeError(f"Radarr API error {response.status}: {text}")
+            if response.content_type == "application/json":
+                return await response.json()
+            return await response.text()
+
+    async def get_movies(self) -> List[Dict[str, Any]]:
+        data = await self._request("GET", "/api/v3/movie")
+        return data or []
+
+    async def get_root_folders(self) -> List[Dict[str, Any]]:
+        data = await self._request("GET", "/api/v3/rootFolder")
+        return data or []
+
+    async def get_quality_profiles(self) -> List[Dict[str, Any]]:
+        data = await self._request("GET", "/api/v3/qualityProfile")
+        return data or []
+
+    async def lookup_movie(
+        self,
+        *,
+        tmdb_id: Optional[str] = None,
+        imdb_id: Optional[str] = None,
+        term: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, str] = {}
+        if tmdb_id:
+            params["term"] = f"tmdb:{tmdb_id}"
+        elif imdb_id:
+            params["term"] = f"imdb:{imdb_id}"
+        elif term:
+            params["term"] = term
+        else:
+            raise ValueError("A tmdb_id, imdb_id, or term is required for lookup")
+
+        data = await self._request("GET", "/api/v3/movie/lookup", params=params)
+        return data or []
+
+    async def get_movie(
+        self,
+        *,
+        tmdb_id: Optional[str] = None,
+        imdb_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if tmdb_id:
+            params["tmdbId"] = tmdb_id
+        if imdb_id:
+            params["imdbId"] = imdb_id
+        if not params:
+            raise ValueError("tmdb_id or imdb_id required to fetch Radarr movie")
+
+        data = await self._request("GET", "/api/v3/movie", params=params)
+        return data or []
+
+    async def add_movie(self, movie_payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await self._request("POST", "/api/v3/movie", json_body=movie_payload)
+
+    async def trigger_movie_search(self, movie_id: int) -> Dict[str, Any]:
+        payload = {
+            "name": "MoviesSearch",
+            "movieIds": [int(movie_id)],
+        }
+        return await self._request("POST", "/api/v3/command", json_body=payload)
+
+    async def search_releases(
+        self,
+        *,
+        movie_id: Optional[int] = None,
+        tmdb_id: Optional[str] = None,
+        imdb_id: Optional[str] = None,
+        term: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, Any] = {}
+        if movie_id:
+            params["movieId"] = int(movie_id)
+        if tmdb_id:
+            params["tmdbId"] = tmdb_id
+        if imdb_id:
+            params["imdbId"] = imdb_id
+        if term:
+            params["term"] = term
+
+        if not params:
+            raise ValueError("A movie identifier or search term is required for release search")
+
+        data = await self._request("GET", "/api/v3/release", params=params)
+        return data or []

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -114,6 +114,96 @@ body {
     text-align: right;
 }
 
+.radarr-hero {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-radius: 8px;
+    padding: 1rem;
+}
+
+.radarr-hero-value {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fff;
+}
+
+.radarr-hero-label {
+    font-size: 0.85rem;
+    color: #9ca3af;
+}
+
+.radarr-selected {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 1rem;
+}
+
+.radarr-action-buttons .btn {
+    margin-left: 0.5rem;
+}
+
+.radarr-badge {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+}
+
+.radarr-releases {
+    background-color: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    padding: 1rem;
+}
+
+.radarr-release-actions .btn {
+    min-width: 130px;
+}
+
+.radarr-release-empty {
+    display: none;
+}
+
+.radarr-release-list .list-group-item {
+    background-color: transparent;
+    border-color: rgba(255, 255, 255, 0.08);
+    color: inherit;
+    padding: 0.75rem 0;
+}
+
+.radarr-release-item + .radarr-release-item {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.radarr-release-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.radarr-release-meta {
+    font-size: 0.8rem;
+    color: #9ca3af;
+}
+
+.radarr-release-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+}
+
+.radarr-release-tags .badge {
+    font-size: 0.7rem;
+    text-transform: none;
+    letter-spacing: 0.01em;
+}
+
+.list-group-item.radarr-selectable {
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.list-group-item.radarr-selectable.active,
+.list-group-item.radarr-selectable:hover {
+    background-color: rgba(49, 130, 206, 0.15);
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
     .stat-box {

--- a/templates/index.html
+++ b/templates/index.html
@@ -540,7 +540,89 @@
                             </div>
                         </div>
                     </div>
-                    
+
+                    <!-- Radarr Section -->
+                    <div class="dashboard-section">
+                        <h4>Radarr Integration</h4>
+                        <div class="card">
+                            <div class="card-body">
+                                <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+                                    <div>
+                                        <span id="radarr-status-badge" class="badge bg-secondary">Disabled</span>
+                                        <small id="radarr-status-message" class="text-muted ms-2">Not configured</small>
+                                    </div>
+                                    <div>
+                                        <button type="button" id="radarr-refresh-btn" class="btn btn-outline-light btn-sm">
+                                            <i class="fas fa-sync-alt"></i> Refresh
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="row text-center radarr-hero-row">
+                                    <div class="col-md-4 col-sm-4 col-12 mb-3">
+                                        <div class="radarr-hero">
+                                            <div class="radarr-hero-value" id="radarr-matched-count">0</div>
+                                            <div class="radarr-hero-label">Matched Titles</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-4 col-sm-4 col-12 mb-3">
+                                        <div class="radarr-hero">
+                                            <div class="radarr-hero-value" id="radarr-monitored-count">0</div>
+                                            <div class="radarr-hero-label">Monitored in Radarr</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-4 col-sm-4 col-12 mb-3">
+                                        <div class="radarr-hero">
+                                            <div class="radarr-hero-value" id="radarr-missing-count">0</div>
+                                            <div class="radarr-hero-label">Needs Radarr</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div id="radarr-selected-movie" class="radarr-selected mt-3">
+                                    <h5 class="d-flex align-items-center justify-content-between">
+                                        <span id="radarr-selected-title">Select a movie to check Radarr status</span>
+                                        <span class="radarr-action-buttons">
+                                            <button type="button" id="radarr-check-btn" class="btn btn-primary btn-sm" disabled>
+                                                <i class="fas fa-search"></i> Check Radarr
+                                            </button>
+                                            <button type="button" id="radarr-add-btn" class="btn btn-success btn-sm" disabled>
+                                                <i class="fas fa-plus"></i> Add to Radarr
+                                            </button>
+                                            <a id="radarr-view-link" href="#" target="_blank" rel="noopener" class="btn btn-outline-secondary btn-sm" style="display:none;">
+                                                <i class="fas fa-external-link-alt"></i> View in Radarr
+                                            </a>
+                                        </span>
+                                    </h5>
+                                    <p id="radarr-selected-status" class="small text-muted mb-0"></p>
+                                    <div id="radarr-release-container" class="radarr-releases mt-4">
+                                        <div class="d-flex flex-wrap justify-content-between align-items-start gap-3">
+                                            <div>
+                                                <h6 class="mb-1">Radarr Release Search</h6>
+                                                <div id="radarr-release-summary" class="text-muted small">Select a movie to begin.</div>
+                                            </div>
+                                            <div class="btn-group radarr-release-actions" role="group">
+                                                <button type="button" id="radarr-release-search-btn" class="btn btn-outline-primary btn-sm" disabled>
+                                                    <i class="fas fa-search"></i> Search Releases
+                                                </button>
+                                                <button type="button" id="radarr-release-refresh-btn" class="btn btn-outline-secondary btn-sm" disabled>
+                                                    <i class="fas fa-sync-alt"></i> Refresh Search
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3">
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" type="checkbox" id="radarr-filter-ipt" disabled>
+                                                <label class="form-check-label" for="radarr-filter-ipt">Only show FEL/IPT matches</label>
+                                            </div>
+                                            <small id="radarr-filter-message" class="text-muted"></small>
+                                        </div>
+                                        <div id="radarr-release-empty" class="radarr-release-empty text-muted small mt-3">Run a release search to see available results.</div>
+                                        <ul id="radarr-release-list" class="list-group list-group-flush radarr-release-list mt-2"></ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Collection Changes Section -->
                     <div class="dashboard-section">
                         <h4>Collection Changes</h4>
@@ -762,7 +844,55 @@
                                         </div>
                                     </div>
                                 </div>
-                                
+
+                                <!-- Radarr Settings -->
+                                <div class="form-section">
+                                    <h5>Radarr Integration</h5>
+                                    <p class="form-text">Connect FELScanner to Radarr to monitor which titles are already managed.</p>
+                                    <div class="row g-3 align-items-end">
+                                        <div class="col-md-6">
+                                            <label for="settings-radarr-url" class="form-label">Radarr Base URL</label>
+                                            <input type="text" class="form-control" id="settings-radarr-url" placeholder="http://localhost:7878">
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="settings-radarr-api-key" class="form-label">API Key</label>
+                                            <input type="password" class="form-control" id="settings-radarr-api-key">
+                                        </div>
+                                        <div class="col-md-2 d-grid">
+                                            <button type="button" id="test-radarr-btn" class="btn btn-outline-primary">
+                                                <i class="fas fa-plug"></i> Test
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="row g-3 mt-2">
+                                        <div class="col-md-6">
+                                            <label for="settings-radarr-root-folder" class="form-label">Root Folder</label>
+                                            <select class="form-select" id="settings-radarr-root-folder">
+                                                <option value="">Select a root folder</option>
+                                            </select>
+                                        </div>
+                                        <div class="col-md-6">
+                                            <label for="settings-radarr-quality-profile" class="form-label">Quality Profile</label>
+                                            <select class="form-select" id="settings-radarr-quality-profile">
+                                                <option value="">Select a quality profile</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="form-check form-switch mt-3">
+                                        <input class="form-check-input" type="checkbox" id="settings-radarr-auto-import">
+                                        <label class="form-check-label" for="settings-radarr-auto-import">
+                                            Automatically monitor new additions when adding to Radarr
+                                        </label>
+                                    </div>
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" id="settings-radarr-dry-run" checked>
+                                        <label class="form-check-label" for="settings-radarr-dry-run">
+                                            Dry run mode (preview add actions without sending to Radarr)
+                                        </label>
+                                    </div>
+                                    <div id="settings-radarr-test-result" class="form-text text-muted mt-2"></div>
+                                </div>
+
                                 <!-- IPTScanner Settings -->
                                 <div class="form-section">
                                     <h5>IPTScanner Settings</h5>


### PR DESCRIPTION
## Summary
- load IPTorrents torrent snapshots for reuse and expose `/api/radarr/releases` to return and optionally filter Radarr release search results
- extend the Radarr client with helpers for manual search triggers and release lookups used by the new endpoint
- add dashboard controls, styling, and scripting to run release searches, apply the FEL/IPT filter, and render live release metadata

## Testing
- python -m compileall app.py integrations/radarr.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c4ff86b883219d0f66d60dc20a51