### PR TITLE
Add EXIF metadata explorer backend and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ fetch-debug.html
 felscanner-data/
 iptradar/*.html
 iptradar/*.png
+metadata-cache.json
 
 # Docker
 *.pem

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# FELScanner (newgui branch)
+# FELScanner
 
-FELScanner is a Dolby Vision/TrueHD intelligence layer for Plex. It crawls your library, curates collections, produces detailed reports, and now ships with a Vue/Tailwind control center that surfaces live Dolby Vision metrics, Atmos coverage, and IPTorrents discoveries at a glance.
+FELScanner is a Dolby Vision/TrueHD intelligence layer for Plex. It crawls your library, curates collections, produces detailed reports, and ships with a Vue/Tailwind control center that surfaces live Dolby Vision metrics, Atmos coverage, IPTorrents discoveries, and smart connection monitoring at a glance.
 
 ## Key Capabilities
 
 - **Plex Dolby Vision Profiler** – classifies every movie by Dolby Vision profile (highlighting Profile 7 FEL), FEL/MEL status, and Atmos availability.
 - **Smart Collections** – keeps Plex collections (All DV, FEL, Atmos) in sync based on scan results with one-click verify & repair.
+- **On-demand Metadata Explorer** – cached Plex metadata with click-to-run ffprobe analysis, version switching, and per-track details.
 - **Insight Dashboard (Vue + Tailwind)** – the landing page (`/`) shows live scan status, DV/Atmos ratios, FEL overlaps, yearly growth trends, recent additions, connection health, and cached IPTorrents hits.
+- **Intelligent Connection Monitoring** – automatic periodic health checks for all external services with smart status messages, test buttons, and one-click connection attempts.
+- **Comprehensive Settings Panel** – configure all services (Plex, Telegram, IPTorrents, FlareSolverr) through an integrated modal with live connection testing.
 - **Detailed Exports** – generates JSON/CSV snapshots (`exports/`) with per-title metadata including bitrate, file size, and audio tracks.
 - **FlareSolverr-powered IPTorrents Monitor** – polls IPTorrents via FlareSolverr, tracks new FEL releases, and exposes cached results to the dashboard.
 - **REST endpoints for automation** – JSON APIs expose scan state, rich DV metrics, report manifests, and connection telemetry for external tooling.
@@ -47,6 +50,8 @@ FELScanner (Flask)
 | `GET /api/metrics`  | Dolby Vision analytics (profiles, overlaps, quality) |
 | `GET /api/reports`  | Recent report manifest (filename, timestamp, size)   |
 | `GET /api/connections` | Plex/IPT/Telegram connection status               |
+| `GET /api/movies`  | Cached Plex metadata overview (`?refresh=1` to rebuild cache) |
+| `GET /api/movies/<rating_key>` | Detailed metadata for a movie; add `?refresh=1` for live ffprobe |
 | `POST /actions/scan`| Trigger full scan (`operation=scan` or `verify`)     |
 | `POST /actions/monitor` | Start/stop monitor (`action=start|stop`)        |
 | `POST /actions/ipt-fetch` | Force an IPTorrents fetch via FlareSolverr   |
@@ -55,17 +60,17 @@ FELScanner (Flask)
 
 - Python 3.9+ (tested on macOS/Linux)
 - Node.js 18+ (for IPT monitor scripts)
+- FFmpeg's `ffprobe` binary available on PATH (or configure `FFPROBE_PATH`)
 - Plex server reachable via URL/token
 - FlareSolverr ≥ v3 (Chromium solving Cloudflare) exposed to FELScanner
 - IPTorrents cookies (`uid`, `pass`) with active account
 
 ## Installation & Setup
 
-### 1. Clone and branch
+### 1. Clone repository
 ```bash
 git clone https://github.com/rohanpandula/FELScanner.git
 cd FELScanner
-git checkout newgui
 ```
 
 ### 2. Python environment
@@ -89,6 +94,7 @@ Either export environment vars or create `.env` (keys mirror `.env.example`):
 export PLEX_URL="http://10.0.0.104:32400"
 export PLEX_TOKEN="DyEmuNtvXz29zQFqGrHn"
 export LIBRARY_NAME="Movies"
+export FFPROBE_PATH="/usr/local/bin/ffprobe"
 export IPT_UID="<ipt uid>"
 export IPT_PASS="<ipt pass>"
 export FLARESOLVERR_URL="http://localhost:8191"
@@ -114,21 +120,26 @@ cd iptscanner
 node monitor-iptorrents.js
 ```
 
-## Dashboard Guide (new GUI)
+## Dashboard Guide
 
 - **Library snapshot** – total DV/FEL/Atmos counts with percent-of-library badges.
 - **Recent DV additions** – top eight titles (profile, Atmos, FEL, bitrate, file size).
-- **Profile distribution (Chart.js)** – doughnut chart of DV profile mix with light/dark toggle.
+- **Metadata Explorer** – cached Plex metadata list with live ffprobe detail on selection, Dolby Vision/Atmos/resolution filters, and per-version stream breakdowns sourced from Plex XML and ffprobe.
 - **Atmos & FEL insights** – overlap numbers, average DV bitrate and file size.
 - **Monitor controls** – buttons to scan, verify collections, start/stop monitor, and force IPT fetch.
-- **Connections** – real-time status for Plex, IPTorrents (last/next sync, 24h delta), Telegram, API server.
+- **Smart Connections Panel** – real-time health monitoring with automatic periodic checks:
+  - **Plex**: Checked every 10 minutes, shows movie count and last check time
+  - **Telegram**: Checked hourly, displays bot name and status
+  - **IPTorrents**: Shows time until next scheduled scan and 24h torrent delta
+  - **One-click Connect**: For disconnected services, click "Connect" to attempt automatic connection
+- **Settings Panel** – comprehensive modal for all service configuration with live test buttons
 - **Yearly growth** – normalized bar list of DV additions by year.
-- **Recent reports** – quick access to generated JSON/CSV (download via `/reports`).
 - **IPTorrents cache** – table of cached torrents (title, size, seeds/leechers, relative added).
 
 ## Technical Notes
 
 - **SQLite schema** is in `exports/movie_database.db` (table `movies` with `extra_data` JSON). `_compute_dolby_metrics()` runs SQL aggregates to populate the dashboard metrics.
+- **Metadata cache** lives at `metadata-cache.json` by default (override via `METADATA_CACHE_FILE`). `/api/movies` serves cached summaries; `/api/movies/<rating_key>?refresh=1` runs ffprobe using `FFPROBE_PATH` and updates the cache.
 - **Tailwind CSS** is loaded from CDN; Jinja variables are wrapped in `{% raw %}` to avoid Vue template conflicts.
 - **Vue 3 Composition API** is bundled inline via CDN (no build step). Chart.js is also CDN-loaded.
 - **Auto refresh** polls status/connections every 15 s; manual refresh hits `/api/metrics`,`/api/reports`,`/api/iptscanner/torrents`.

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,24 @@
+"""
+FELScanner Integration Modules
+
+Provides API clients and orchestration for external services:
+- qBittorrent: Direct torrent download management
+- Radarr: Movie library and folder path queries
+- Telegram: Interactive approval notifications
+- UpgradeDetector: Smart notification filtering
+- DownloadManager: Orchestrates the complete workflow
+"""
+
+from .qbittorrent import QBittorrentClient
+from .radarr import RadarrClient
+from .upgrade_detector import UpgradeDetector
+from .telegram_handler import TelegramDownloadHandler
+from .download_manager import DownloadManager
+
+__all__ = [
+    'QBittorrentClient',
+    'RadarrClient',
+    'UpgradeDetector',
+    'TelegramDownloadHandler',
+    'DownloadManager'
+]

--- a/integrations/download_manager.py
+++ b/integrations/download_manager.py
@@ -1,0 +1,416 @@
+"""
+Download Manager
+
+Orchestrates the complete workflow:
+1. IPT discovery → Parse quality
+2. Check Plex library → Get current quality
+3. Smart upgrade detection → Should we notify?
+4. Get Radarr folder path
+5. Send Telegram approval request
+6. Execute download on approval
+"""
+
+import logging
+import hashlib
+import time
+import json
+import re
+from typing import Dict, Optional, Any
+from datetime import datetime
+
+log = logging.getLogger(__name__)
+
+
+class DownloadManager:
+    """Orchestrates IPT discoveries through to qBittorrent downloads"""
+
+    def __init__(self, qbt_client, radarr_client, telegram_handler, upgrade_detector, scanner_db):
+        """
+        Initialize download manager
+
+        Args:
+            qbt_client: QBittorrentClient instance
+            radarr_client: RadarrClient instance
+            telegram_handler: TelegramDownloadHandler instance
+            upgrade_detector: UpgradeDetector instance
+            scanner_db: MovieDatabase instance from scanner
+        """
+        self.qbt = qbt_client
+        self.radarr = radarr_client
+        self.telegram = telegram_handler
+        self.upgrade_detector = upgrade_detector
+        self.db = scanner_db
+
+        # Set callback handler for Telegram responses
+        self.telegram.set_callback_handler(self.execute_download)
+
+    async def process_ipt_discovery(self, torrent_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Main entry point when IPT finds new torrent
+
+        Args:
+            torrent_data: Dict with torrent info (title, url/magnet_link, etc.)
+
+        Returns:
+            Dict with processing status and details
+        """
+        try:
+            # Parse torrent title
+            parsed = self.parse_torrent_title(torrent_data['title'])
+            if not parsed:
+                return {"status": "skip", "reason": "Could not parse torrent title"}
+
+            log.info(f"Processing IPT discovery: {parsed['title']} ({parsed['year']})")
+
+            # Look up movie in Plex database
+            movie = self.find_movie_in_db(parsed['title'], parsed.get('year'))
+
+            if not movie:
+                return {
+                    "status": "skip",
+                    "reason": "Movie not in your Plex library"
+                }
+
+            # Get current quality details
+            current_quality = self.get_current_quality(movie)
+
+            # Parse new quality from torrent
+            new_quality = self.upgrade_detector.parse_torrent_quality(torrent_data['title'])
+
+            # Smart upgrade detection
+            should_notify, reason = self.upgrade_detector.is_notification_worthy(
+                current_quality,
+                new_quality
+            )
+
+            if not should_notify:
+                log.info(f"Skipping {movie['title']}: {reason}")
+                return {"status": "skip", "reason": reason}
+
+            log.info(f"Upgrade detected for {movie['title']}: {reason}")
+
+            # Get Radarr folder path
+            radarr_folder = await self.radarr.get_movie_folder(
+                parsed['title'],
+                parsed.get('year')
+            )
+
+            if not radarr_folder:
+                return {
+                    "status": "error",
+                    "reason": "Movie not found in Radarr or no folder path"
+                }
+
+            # Build download request
+            request_id = self.generate_request_id(movie['title'], new_quality)
+
+            download_request = {
+                'request_id': request_id,
+                'movie_title': movie['title'],
+                'year': movie.get('year'),
+                'current_quality': self.format_current_quality(current_quality),
+                'new_quality': self.format_new_quality(new_quality),
+                'upgrade_reason': reason,
+                'torrent_url': torrent_data.get('magnet_link') or torrent_data.get('url'),
+                'torrent_title': torrent_data['title'],
+                'target_folder': radarr_folder,
+                'quality_type': 'fel' if new_quality.get('is_fel') else 'dv' if new_quality.get('dv_profile') else 'hdr',
+                'created_at': datetime.now().isoformat()
+            }
+
+            # Store in database (we'll add this method)
+            self.store_pending_download(request_id, download_request)
+
+            # Send Telegram approval request
+            message_id = self.telegram.send_approval_request(download_request)
+
+            if message_id:
+                log.info(f"Sent approval request for {movie['title']} (request_id: {request_id})")
+                return {
+                    "status": "pending_approval",
+                    "request_id": request_id,
+                    "message_id": message_id
+                }
+            else:
+                return {
+                    "status": "error",
+                    "reason": "Failed to send Telegram notification"
+                }
+
+        except Exception as e:
+            log.error(f"Error processing IPT discovery: {e}", exc_info=True)
+            return {
+                "status": "error",
+                "reason": str(e)
+            }
+
+    async def execute_download(self, request_id: str, action: str = "approved") -> Dict[str, Any]:
+        """
+        Execute approved download
+
+        Args:
+            request_id: Download request ID
+            action: Action taken (approved/declined)
+
+        Returns:
+            Dict with execution result
+        """
+        if action != "approved":
+            log.info(f"Download {request_id} was declined")
+            return {"success": True, "action": "declined"}
+
+        try:
+            # Get request details from database
+            download_data = self.get_pending_download(request_id)
+
+            if not download_data:
+                return {"success": False, "error": "Download request not found"}
+
+            movie_title = download_data['movie_title']
+            target_folder = download_data['target_folder']
+            torrent_url = download_data['torrent_url']
+            quality_type = download_data.get('quality_type', 'unknown')
+
+            log.info(f"Executing download: {movie_title} to {target_folder}")
+
+            # Send to qBittorrent
+            result = await self.qbt.add_torrent(
+                url_or_magnet=torrent_url,
+                save_path=target_folder,
+                category=f"movies-{quality_type}",
+                paused=False,  # Will use settings
+                sequential=True  # Will use settings
+            )
+
+            if result.get('success'):
+                # Update database status
+                self.mark_download_started(request_id, result.get('hash'))
+
+                # Send confirmation notification
+                self.telegram.send_download_started(
+                    movie_title,
+                    download_data['new_quality'],
+                    target_folder
+                )
+
+                log.info(f"Successfully started download: {movie_title}")
+                return {
+                    "success": True,
+                    "movie_title": movie_title,
+                    "torrent_hash": result.get('hash')
+                }
+            else:
+                error = result.get('error', 'Unknown error')
+                log.error(f"Failed to add torrent: {error}")
+
+                # Send error notification
+                self.telegram.send_download_error(movie_title, error)
+
+                return {
+                    "success": False,
+                    "error": error
+                }
+
+        except Exception as e:
+            log.error(f"Error executing download: {e}", exc_info=True)
+            return {
+                "success": False,
+                "error": str(e)
+            }
+
+    def parse_torrent_title(self, title: str) -> Optional[Dict[str, Any]]:
+        """
+        Parse movie title and year from torrent title
+
+        Args:
+            title: Torrent title string
+
+        Returns:
+            Dict with parsed info or None
+        """
+        # Common pattern: "Movie Name 2021 2160p DV FEL..."
+        # Try to extract title and year
+
+        # Pattern 1: Title (Year) or Title.Year
+        pattern1 = r'^(.+?)[.\s]+(\d{4})[.\s]'
+        match = re.search(pattern1, title)
+
+        if match:
+            movie_title = match.group(1).replace('.', ' ').strip()
+            year = int(match.group(2))
+
+            # Clean up title
+            movie_title = re.sub(r'\s+', ' ', movie_title)
+
+            return {
+                'title': movie_title,
+                'year': year
+            }
+
+        # Pattern 2: Just grab everything before first year-like number
+        pattern2 = r'^(.+?)\s+(\d{4})'
+        match = re.search(pattern2, title)
+
+        if match:
+            movie_title = match.group(1).strip()
+            year = int(match.group(2))
+
+            return {
+                'title': movie_title,
+                'year': year
+            }
+
+        log.warning(f"Could not parse torrent title: {title}")
+        return None
+
+    def find_movie_in_db(self, title: str, year: Optional[int] = None) -> Optional[Dict[str, Any]]:
+        """
+        Find movie in Plex database
+
+        Args:
+            title: Movie title
+            year: Release year (optional)
+
+        Returns:
+            Movie dict or None
+        """
+        try:
+            # Use scanner database to query
+            with self.db.get_connection() as conn:
+                cursor = conn.cursor()
+
+                # Normalize title for comparison
+                search_title = title.lower().strip()
+
+                if year:
+                    # Try with year from extra_data
+                    cursor.execute("""
+                        SELECT * FROM movies
+                        WHERE LOWER(title) = ?
+                        AND json_extract(extra_data, '$.year') = ?
+                    """, (search_title, str(year)))
+
+                    result = cursor.fetchone()
+                    if result:
+                        return dict(result)
+
+                # Fallback to title-only search
+                cursor.execute("""
+                    SELECT * FROM movies
+                    WHERE LOWER(title) = ?
+                    LIMIT 1
+                """, (search_title,))
+
+                result = cursor.fetchone()
+                if result:
+                    return dict(result)
+
+                return None
+
+        except Exception as e:
+            log.error(f"Error finding movie in database: {e}")
+            return None
+
+    def get_current_quality(self, movie: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Extract current quality details from movie record
+
+        Args:
+            movie: Movie dict from database
+
+        Returns:
+            Quality dict
+        """
+        extra_data = {}
+        if movie.get('extra_data'):
+            try:
+                extra_data = json.loads(movie['extra_data'])
+            except:
+                pass
+
+        return {
+            'dv_profile': movie.get('dv_profile'),
+            'dv_fel': bool(movie.get('dv_fel')),
+            'has_atmos': bool(movie.get('has_atmos')),
+            'file_size': extra_data.get('file_size'),
+            'bitrate': extra_data.get('video_bitrate'),
+            'resolution': self.guess_resolution(extra_data)
+        }
+
+    def guess_resolution(self, extra_data: Dict) -> str:
+        """Guess resolution from available data"""
+        # Could be enhanced based on extra_data
+        return extra_data.get('resolution', 'unknown')
+
+    def format_current_quality(self, quality: Dict[str, Any]) -> str:
+        """Format current quality for display"""
+        lines = []
+
+        # DV info
+        if quality.get('dv_profile'):
+            fel_status = " FEL" if quality.get('dv_fel') else " MEL"
+            lines.append(f"• DV Profile {quality['dv_profile']}{fel_status}")
+        else:
+            lines.append("• HDR10 / SDR")
+
+        # File size
+        if quality.get('file_size'):
+            size_gb = quality['file_size'] / (1024 ** 3)
+            lines.append(f"• {size_gb:.1f} GB")
+
+        # Bitrate
+        if quality.get('bitrate'):
+            lines.append(f"• {quality['bitrate']}")
+
+        # Resolution
+        if quality.get('resolution') and quality['resolution'] != 'unknown':
+            lines.append(f"• {quality['resolution']}")
+
+        # Atmos
+        if quality.get('has_atmos'):
+            lines.append("• TrueHD Atmos ✓")
+
+        return "\n".join(lines) if lines else "Unknown"
+
+    def format_new_quality(self, quality: Dict[str, Any]) -> str:
+        """Format new quality for display"""
+        lines = []
+
+        # DV info
+        if quality.get('dv_profile'):
+            if quality.get('is_fel'):
+                lines.append(f"• DV Profile {quality['dv_profile']} FEL (BL+EL+RPU)")
+            else:
+                lines.append(f"• DV Profile {quality['dv_profile']}")
+        else:
+            lines.append("• HDR10")
+
+        # Resolution
+        if quality.get('resolution') and quality['resolution'] != 'unknown':
+            lines.append(f"• {quality['resolution']}")
+
+        # Atmos
+        if quality.get('has_atmos'):
+            lines.append("• TrueHD Atmos ✓")
+
+        lines.append("• From IPTorrents")
+
+        return "\n".join(lines)
+
+    def generate_request_id(self, movie_title: str, quality: Dict) -> str:
+        """Generate unique request ID"""
+        unique_str = f"{movie_title}{quality}{time.time()}"
+        return hashlib.md5(unique_str.encode()).hexdigest()[:12]
+
+    # Database methods (delegate to scanner database)
+    def store_pending_download(self, request_id: str, download_data: Dict):
+        """Store pending download in database"""
+        self.db.store_pending_download(request_id, download_data)
+
+    def get_pending_download(self, request_id: str) -> Optional[Dict]:
+        """Get pending download from database"""
+        return self.db.get_pending_download(request_id)
+
+    def mark_download_started(self, request_id: str, torrent_hash: Optional[str]):
+        """Mark download as started in database"""
+        self.db.mark_download_started(request_id, torrent_hash)

--- a/integrations/qbittorrent.py
+++ b/integrations/qbittorrent.py
@@ -1,0 +1,260 @@
+"""
+qBittorrent Web API Client
+
+Handles communication with qBittorrent for adding and managing torrents.
+Supports both authenticated and LAN-only (no auth) modes.
+"""
+
+import logging
+import aiohttp
+from typing import Dict, List, Optional, Any
+from urllib.parse import urljoin
+
+log = logging.getLogger(__name__)
+
+
+class QBittorrentClient:
+    """Async client for qBittorrent Web API"""
+
+    def __init__(self, host: str, port: int = 8080, username: str = "", password: str = ""):
+        """
+        Initialize qBittorrent client
+
+        Args:
+            host: qBittorrent host (e.g., "10.0.0.63")
+            port: WebUI port (default 8080)
+            username: Username for authentication (empty for LAN mode)
+            password: Password for authentication (empty for LAN mode)
+        """
+        self.base_url = f"http://{host}:{port}"
+        self.username = username
+        self.password = password
+        self.session: Optional[aiohttp.ClientSession] = None
+        self._session_cookie: Optional[str] = None
+        self._requires_auth = bool(username and password)
+
+    async def _ensure_session(self):
+        """Ensure HTTP session exists and is authenticated if needed"""
+        if not self.session or self.session.closed:
+            self.session = aiohttp.ClientSession()
+
+        # Authenticate if required and not yet authenticated
+        if self._requires_auth and not self._session_cookie:
+            await self._login()
+
+    async def _login(self):
+        """Authenticate with qBittorrent WebUI"""
+        if not self.session:
+            return
+
+        try:
+            login_url = urljoin(self.base_url, "/api/v2/auth/login")
+            data = aiohttp.FormData()
+            data.add_field('username', self.username)
+            data.add_field('password', self.password)
+
+            async with self.session.post(login_url, data=data) as response:
+                if response.status == 200:
+                    text = await response.text()
+                    if text == "Ok.":
+                        # Extract SID cookie
+                        cookies = self.session.cookie_jar.filter_cookies(self.base_url)
+                        if 'SID' in cookies:
+                            self._session_cookie = cookies['SID'].value
+                            log.info("qBittorrent authentication successful")
+                        return
+
+                log.error(f"qBittorrent login failed: {response.status}")
+                raise RuntimeError(f"qBittorrent authentication failed: {response.status}")
+        except Exception as e:
+            log.error(f"Error during qBittorrent login: {e}")
+            raise
+
+    async def close(self):
+        """Close HTTP session"""
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+    async def add_torrent(
+        self,
+        url_or_magnet: str,
+        save_path: str,
+        category: str = "movies",
+        paused: bool = False,
+        sequential: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Add torrent to qBittorrent
+
+        Args:
+            url_or_magnet: Torrent URL or magnet link
+            save_path: Directory to save files
+            category: Category for organization
+            paused: Add in paused state
+            sequential: Enable sequential download
+
+        Returns:
+            dict with status and torrent hash
+        """
+        await self._ensure_session()
+
+        if not self.session:
+            raise RuntimeError("Failed to create session")
+
+        try:
+            add_url = urljoin(self.base_url, "/api/v2/torrents/add")
+
+            data = aiohttp.FormData()
+            data.add_field('urls', url_or_magnet)
+            data.add_field('savepath', save_path)
+            data.add_field('category', category)
+            data.add_field('paused', 'true' if paused else 'false')
+            data.add_field('sequentialDownload', 'true' if sequential else 'false')
+
+            async with self.session.post(add_url, data=data) as response:
+                if response.status == 200:
+                    text = await response.text()
+                    if text == "Ok.":
+                        log.info(f"Successfully added torrent to qBittorrent: {save_path}")
+
+                        # Try to get hash by looking for recently added torrent
+                        # (qBittorrent doesn't return hash directly from add endpoint)
+                        torrents = await self.get_torrents(category=category)
+                        if torrents:
+                            # Return most recently added torrent in this category
+                            latest = max(torrents, key=lambda t: t.get('added_on', 0))
+                            return {
+                                'success': True,
+                                'hash': latest.get('hash'),
+                                'name': latest.get('name')
+                            }
+
+                        return {'success': True, 'hash': None}
+                    else:
+                        log.error(f"qBittorrent add failed: {text}")
+                        return {'success': False, 'error': text}
+                else:
+                    error_text = await response.text()
+                    log.error(f"qBittorrent add failed: {response.status} - {error_text}")
+                    return {'success': False, 'error': f"HTTP {response.status}"}
+        except Exception as e:
+            log.error(f"Error adding torrent to qBittorrent: {e}")
+            return {'success': False, 'error': str(e)}
+
+    async def get_torrents(
+        self,
+        category: Optional[str] = None,
+        filter_status: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Get list of torrents
+
+        Args:
+            category: Filter by category
+            filter_status: Filter by status (downloading, completed, etc.)
+
+        Returns:
+            List of torrent info dicts
+        """
+        await self._ensure_session()
+
+        if not self.session:
+            return []
+
+        try:
+            info_url = urljoin(self.base_url, "/api/v2/torrents/info")
+            params = {}
+            if category:
+                params['category'] = category
+            if filter_status:
+                params['filter'] = filter_status
+
+            async with self.session.get(info_url, params=params) as response:
+                if response.status == 200:
+                    return await response.json()
+                else:
+                    log.error(f"Failed to get torrents: {response.status}")
+                    return []
+        except Exception as e:
+            log.error(f"Error getting torrents: {e}")
+            return []
+
+    async def get_torrent_info(self, torrent_hash: str) -> Optional[Dict[str, Any]]:
+        """
+        Get detailed info for specific torrent
+
+        Args:
+            torrent_hash: Torrent hash
+
+        Returns:
+            Torrent info dict or None
+        """
+        torrents = await self.get_torrents()
+        for torrent in torrents:
+            if torrent.get('hash') == torrent_hash:
+                return torrent
+        return None
+
+    async def test_connection(self) -> Dict[str, Any]:
+        """
+        Test connection to qBittorrent
+
+        Returns:
+            dict with success status and details
+        """
+        try:
+            await self._ensure_session()
+
+            if not self.session:
+                return {'success': False, 'error': 'Failed to create session'}
+
+            # Test API by getting version
+            version_url = urljoin(self.base_url, "/api/v2/app/version")
+            async with self.session.get(version_url) as response:
+                if response.status == 200:
+                    version = await response.text()
+
+                    # Get torrent count
+                    torrents = await self.get_torrents()
+
+                    return {
+                        'success': True,
+                        'version': version,
+                        'torrent_count': len(torrents),
+                        'message': f'Connected to qBittorrent {version}'
+                    }
+                else:
+                    return {
+                        'success': False,
+                        'error': f'HTTP {response.status}'
+                    }
+        except Exception as e:
+            log.error(f"qBittorrent connection test failed: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+
+    async def get_categories(self) -> Dict[str, Dict]:
+        """
+        Get all categories
+
+        Returns:
+            Dict mapping category names to category info
+        """
+        await self._ensure_session()
+
+        if not self.session:
+            return {}
+
+        try:
+            categories_url = urljoin(self.base_url, "/api/v2/torrents/categories")
+            async with self.session.get(categories_url) as response:
+                if response.status == 200:
+                    return await response.json()
+                else:
+                    log.error(f"Failed to get categories: {response.status}")
+                    return {}
+        except Exception as e:
+            log.error(f"Error getting categories: {e}")
+            return {}

--- a/integrations/radarr.py
+++ b/integrations/radarr.py
@@ -1,0 +1,264 @@
+"""
+Radarr API Client
+
+Handles communication with Radarr for movie library queries and folder path lookups.
+Used to find where movies are stored for parallel version downloads.
+"""
+
+import logging
+import aiohttp
+from typing import Dict, List, Optional, Any
+from urllib.parse import urljoin
+
+log = logging.getLogger(__name__)
+
+
+class RadarrClient:
+    """Async client for Radarr API v3"""
+
+    def __init__(self, base_url: str, api_key: str, timeout: int = 30):
+        """
+        Initialize Radarr client
+
+        Args:
+            base_url: Radarr base URL (e.g., "http://10.0.0.63:7878")
+            api_key: Radarr API key
+            timeout: Request timeout in seconds
+        """
+        self.base_url = base_url.rstrip('/')
+        self.api_key = api_key
+        self.timeout = timeout
+        self.session: Optional[aiohttp.ClientSession] = None
+
+    async def _ensure_session(self):
+        """Ensure HTTP session exists with API key header"""
+        if not self.session or self.session.closed:
+            headers = {
+                "X-Api-Key": self.api_key,
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            }
+            self.session = aiohttp.ClientSession(
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=self.timeout)
+            )
+
+    async def close(self):
+        """Close HTTP session"""
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict] = None,
+        json_body: Optional[Any] = None
+    ) -> Any:
+        """Make API request"""
+        await self._ensure_session()
+
+        if not self.session:
+            raise RuntimeError("Failed to create session")
+
+        url = urljoin(self.base_url, path)
+
+        try:
+            async with self.session.request(
+                method, url, params=params, json=json_body
+            ) as response:
+                if response.status >= 400:
+                    text = await response.text()
+                    log.error(f"Radarr API error {response.status}: {text}")
+                    raise RuntimeError(f"Radarr API error {response.status}: {text}")
+
+                if response.content_type == "application/json":
+                    return await response.json()
+                return await response.text()
+        except aiohttp.ClientError as e:
+            log.error(f"Radarr request failed: {e}")
+            raise
+
+    async def get_movies(self) -> List[Dict[str, Any]]:
+        """
+        Get all movies in Radarr
+
+        Returns:
+            List of movie dicts
+        """
+        try:
+            data = await self._request("GET", "/api/v3/movie")
+            return data or []
+        except Exception as e:
+            log.error(f"Error getting Radarr movies: {e}")
+            return []
+
+    async def search_movie(
+        self,
+        title: str,
+        year: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Search for movie in Radarr library by title and year
+
+        Args:
+            title: Movie title
+            year: Release year (optional, helps narrow results)
+
+        Returns:
+            Movie dict or None if not found
+        """
+        try:
+            movies = await self.get_movies()
+
+            # Normalize title for comparison
+            search_title = title.lower().strip()
+
+            # First try exact year match if year provided
+            if year:
+                for movie in movies:
+                    movie_title = movie.get('title', '').lower().strip()
+                    movie_year = movie.get('year')
+                    if movie_title == search_title and movie_year == year:
+                        return movie
+
+            # Fallback to title-only match
+            for movie in movies:
+                movie_title = movie.get('title', '').lower().strip()
+                if movie_title == search_title:
+                    return movie
+
+            log.info(f"Movie not found in Radarr: {title} ({year})")
+            return None
+        except Exception as e:
+            log.error(f"Error searching for movie in Radarr: {e}")
+            return None
+
+    async def get_movie_by_id(self, radarr_id: int) -> Optional[Dict[str, Any]]:
+        """
+        Get movie by Radarr ID
+
+        Args:
+            radarr_id: Radarr's internal movie ID
+
+        Returns:
+            Movie dict or None
+        """
+        try:
+            movie = await self._request("GET", f"/api/v3/movie/{radarr_id}")
+            return movie
+        except Exception as e:
+            log.error(f"Error getting movie {radarr_id}: {e}")
+            return None
+
+    async def get_movie_folder(
+        self,
+        title: str,
+        year: Optional[int] = None
+    ) -> Optional[str]:
+        """
+        Get folder path for a movie
+
+        Args:
+            title: Movie title
+            year: Release year
+
+        Returns:
+            Folder path string or None
+        """
+        movie = await self.search_movie(title, year)
+        if movie and 'path' in movie:
+            return movie['path']
+        return None
+
+    async def get_movie_file_info(
+        self,
+        title: str,
+        year: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Get file info for a movie (to show current quality)
+
+        Args:
+            title: Movie title
+            year: Release year
+
+        Returns:
+            Dict with file info or None
+        """
+        movie = await self.search_movie(title, year)
+        if not movie:
+            return None
+
+        file_info = {
+            'folder': movie.get('path'),
+            'has_file': movie.get('hasFile', False),
+            'radarr_id': movie.get('id')
+        }
+
+        # Get movie file details if available
+        if movie.get('movieFile'):
+            movie_file = movie['movieFile']
+            file_info.update({
+                'file_path': movie_file.get('path'),
+                'file_size': movie_file.get('size'),
+                'quality': movie_file.get('quality', {}).get('quality', {}).get('name'),
+                'resolution': movie_file.get('quality', {}).get('quality', {}).get('resolution')
+            })
+
+        return file_info
+
+    async def test_connection(self) -> Dict[str, Any]:
+        """
+        Test connection to Radarr
+
+        Returns:
+            dict with success status and details
+        """
+        try:
+            # Test by getting system status
+            status = await self._request("GET", "/api/v3/system/status")
+
+            # Get movie count
+            movies = await self.get_movies()
+
+            return {
+                'success': True,
+                'version': status.get('version', 'Unknown'),
+                'movie_count': len(movies),
+                'message': f"Connected to Radarr {status.get('version')}"
+            }
+        except Exception as e:
+            log.error(f"Radarr connection test failed: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+
+    async def get_root_folders(self) -> List[Dict[str, Any]]:
+        """
+        Get root folders configured in Radarr
+
+        Returns:
+            List of root folder dicts
+        """
+        try:
+            folders = await self._request("GET", "/api/v3/rootFolder")
+            return folders or []
+        except Exception as e:
+            log.error(f"Error getting root folders: {e}")
+            return []
+
+    async def get_quality_profiles(self) -> List[Dict[str, Any]]:
+        """
+        Get quality profiles configured in Radarr
+
+        Returns:
+            List of quality profile dicts
+        """
+        try:
+            profiles = await self._request("GET", "/api/v3/qualityProfile")
+            return profiles or []
+        except Exception as e:
+            log.error(f"Error getting quality profiles: {e}")
+            return []

--- a/integrations/telegram_handler.py
+++ b/integrations/telegram_handler.py
@@ -1,0 +1,399 @@
+"""
+Telegram Interactive Handler
+
+Sends interactive approval requests via Telegram with inline buttons.
+Handles user responses and tracks pending downloads.
+"""
+
+import logging
+import requests
+import asyncio
+from typing import Dict, Optional, Any, Callable
+from datetime import datetime
+
+log = logging.getLogger(__name__)
+
+
+class TelegramDownloadHandler:
+    """Handles interactive Telegram approval workflow"""
+
+    def __init__(self, bot_token: str, chat_id: str):
+        """
+        Initialize Telegram handler
+
+        Args:
+            bot_token: Telegram bot token
+            chat_id: Target chat ID for notifications
+        """
+        self.bot_token = bot_token
+        self.chat_id = chat_id
+        self.base_url = f"https://api.telegram.org/bot{bot_token}"
+        self.pending_downloads = {}  # message_id -> download_data
+        self.callback_handler: Optional[Callable] = None
+
+    def set_callback_handler(self, handler: Callable):
+        """
+        Set callback function for button presses
+
+        Args:
+            handler: Async function(request_id, action) -> result
+        """
+        self.callback_handler = handler
+
+    def send_approval_request(self, download_request: Dict[str, Any]) -> Optional[int]:
+        """
+        Send approval request with inline buttons
+
+        Args:
+            download_request: Dict with movie details and upgrade info
+
+        Returns:
+            Message ID or None if failed
+        """
+        try:
+            request_id = download_request.get('request_id')
+            movie_title = download_request.get('movie_title', 'Unknown Movie')
+            year = download_request.get('year', '')
+            current_quality = download_request.get('current_quality', 'Unknown')
+            new_quality = download_request.get('new_quality', 'Unknown')
+            target_folder = download_request.get('target_folder', '')
+            upgrade_reason = download_request.get('upgrade_reason', 'Upgrade available')
+
+            # Format message
+            message = self._format_approval_message(
+                movie_title, year, current_quality, new_quality,
+                target_folder, upgrade_reason
+            )
+
+            # Create inline keyboard with buttons
+            keyboard = {
+                "inline_keyboard": [
+                    [
+                        {"text": "✅ Download", "callback_data": f"dl_yes_{request_id}"},
+                        {"text": "❌ Skip", "callback_data": f"dl_no_{request_id}"}
+                    ]
+                ]
+            }
+
+            # Send message
+            url = f"{self.base_url}/sendMessage"
+            payload = {
+                "chat_id": self.chat_id,
+                "text": message,
+                "parse_mode": "HTML",
+                "reply_markup": keyboard
+            }
+
+            response = requests.post(url, json=payload, timeout=10)
+            response.raise_for_status()
+
+            result = response.json()
+            if result.get('ok'):
+                message_id = result['result']['message_id']
+
+                # Store pending download
+                self.pending_downloads[message_id] = {
+                    'request_id': request_id,
+                    'download_data': download_request,
+                    'timestamp': datetime.now()
+                }
+
+                log.info(f"Sent approval request for {movie_title} (message_id: {message_id})")
+                return message_id
+            else:
+                log.error(f"Telegram send failed: {result}")
+                return None
+
+        except Exception as e:
+            log.error(f"Error sending Telegram approval request: {e}")
+            return None
+
+    def _format_approval_message(
+        self,
+        movie_title: str,
+        year: Optional[int],
+        current_quality: str,
+        new_quality: str,
+        target_folder: str,
+        upgrade_reason: str
+    ) -> str:
+        """Format approval message with HTML markup"""
+
+        title_with_year = f"{movie_title} ({year})" if year else movie_title
+
+        message = f"🎬 <b>New Version Available!</b>\n\n"
+        message += f"<b>Movie:</b> {title_with_year}\n\n"
+
+        message += f"📀 <b>Current Quality:</b>\n{current_quality}\n\n"
+        message += f"⭐ <b>New Quality:</b>\n{new_quality}\n\n"
+
+        message += f"💡 <b>Reason:</b> {upgrade_reason}\n\n"
+
+        if target_folder:
+            # Shorten folder path for readability
+            folder_display = target_folder.split('/')[-1] if '/' in target_folder else target_folder
+            message += f"📂 <b>Folder:</b> {folder_display}\n\n"
+
+        message += "Download this version?"
+
+        return message
+
+    def handle_callback(
+        self,
+        callback_data: str,
+        message_id: int,
+        chat_id: int,
+        callback_query_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Handle button press from user
+
+        Args:
+            callback_data: Callback data from button (e.g., "dl_yes_abc123")
+            message_id: Telegram message ID
+            chat_id: Chat ID where button was pressed
+            callback_query_id: Telegram callback query ID (for answerCallbackQuery)
+
+        Returns:
+            Dict with action result
+        """
+        try:
+            # Parse callback data
+            parts = callback_data.split('_', 2)
+            if len(parts) != 3:
+                log.error(f"Invalid callback data: {callback_data}")
+                return {'success': False, 'error': 'Invalid callback data'}
+
+            action = parts[1]  # 'yes' or 'no'
+            request_id = parts[2]
+
+            # Get pending download info
+            pending = self.pending_downloads.get(message_id)
+            if not pending:
+                log.warning(f"No pending download for message {message_id}")
+                return {
+                    'success': False,
+                    'error': 'Download request expired or already processed'
+                }
+
+            download_data = pending['download_data']
+            movie_title = download_data.get('movie_title', 'Unknown')
+
+            if action == "yes":
+                # User approved download
+                log.info(f"User approved download: {movie_title}")
+
+                # Call the callback handler if set
+                callback_result = None
+                if self.callback_handler:
+                    try:
+                        callback_response = self.callback_handler(request_id, "approved")
+                        if asyncio.iscoroutine(callback_response):
+                            callback_result = self._run_coroutine(callback_response)
+                        else:
+                            callback_result = callback_response
+                    except Exception as exc:
+                        log.error(f"Callback handler failed for {movie_title}: {exc}", exc_info=True)
+                        callback_result = {'success': False, 'error': str(exc)}
+
+                if isinstance(callback_result, dict):
+                    result = callback_result
+                    result.setdefault('action', 'approved')
+                    result.setdefault('request_id', request_id)
+                else:
+                    result = {'success': True, 'action': 'approved', 'request_id': request_id}
+
+                if result.get('success'):
+                    message_text = (
+                        f"✅ <b>Download Started</b>\n\n{movie_title}\n\nDownload has been queued."
+                    )
+                    callback_answer = "Download started! 🚀"
+                else:
+                    error_text = result.get('error', 'Download could not be started.')
+                    message_text = (
+                        f"⚠️ <b>Download Failed</b>\n\n{movie_title}\n\n{error_text}"
+                    )
+                    callback_answer = "Download failed"
+
+                # Update message
+                self._update_message(
+                    chat_id, message_id,
+                    message_text
+                )
+
+                # Answer callback query (stop loading animation)
+                self._answer_callback_query(callback_query_id, callback_answer)
+
+            else:
+                # User declined
+                log.info(f"User declined download: {movie_title}")
+                result = {'success': True, 'action': 'declined', 'request_id': request_id}
+
+                # Update message
+                self._update_message(
+                    chat_id, message_id,
+                    f"❌ <b>Skipped</b>\n\n{movie_title}\n\nDownload was not queued."
+                )
+
+                # Answer callback query
+                self._answer_callback_query(callback_query_id, "Skipped")
+
+            # Remove from pending
+            del self.pending_downloads[message_id]
+
+            return result
+
+        except Exception as e:
+            log.error(f"Error handling callback: {e}")
+            return {'success': False, 'error': str(e)}
+
+    def _update_message(self, chat_id: int, message_id: int, new_text: str):
+        """Update message text (remove buttons)"""
+        try:
+            url = f"{self.base_url}/editMessageText"
+            payload = {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "text": new_text,
+                "parse_mode": "HTML"
+            }
+
+            response = requests.post(url, json=payload, timeout=10)
+            response.raise_for_status()
+        except Exception as e:
+            log.error(f"Error updating message: {e}")
+
+    def _answer_callback_query(self, callback_query_id: Optional[str], text: str):
+        """Answer callback query to stop loading animation."""
+        if not callback_query_id:
+            log.debug("No callback_query_id provided; skipping answerCallbackQuery call")
+            return
+
+        try:
+            url = f"{self.base_url}/answerCallbackQuery"
+            payload = {
+                "callback_query_id": callback_query_id,
+                "text": text
+            }
+
+            response = requests.post(url, json=payload, timeout=10)
+            response.raise_for_status()
+        except Exception as e:
+            log.error(f"Error answering callback query: {e}")
+
+    @staticmethod
+    def _run_coroutine(coro):
+        """Run coroutine to completion using a dedicated event loop."""
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+    def send_notification(self, message: str, parse_mode: str = "HTML") -> bool:
+        """
+        Send simple notification (no buttons)
+
+        Args:
+            message: Message text
+            parse_mode: Parse mode (HTML or Markdown)
+
+        Returns:
+            True if successful
+        """
+        try:
+            url = f"{self.base_url}/sendMessage"
+            payload = {
+                "chat_id": self.chat_id,
+                "text": message,
+                "parse_mode": parse_mode
+            }
+
+            response = requests.post(url, json=payload, timeout=10)
+            response.raise_for_status()
+
+            result = response.json()
+            return result.get('ok', False)
+
+        except Exception as e:
+            log.error(f"Error sending notification: {e}")
+            return False
+
+    def send_download_started(self, movie_title: str, quality: str, folder: str):
+        """Send notification that download started"""
+        message = f"🚀 <b>Download Started</b>\n\n"
+        message += f"<b>Movie:</b> {movie_title}\n"
+        message += f"<b>Quality:</b> {quality}\n"
+        message += f"<b>Folder:</b> {folder}"
+
+        self.send_notification(message)
+
+    def send_download_completed(self, movie_title: str, quality: str):
+        """Send notification that download completed"""
+        message = f"✅ <b>Download Complete</b>\n\n"
+        message += f"<b>Movie:</b> {movie_title}\n"
+        message += f"<b>Quality:</b> {quality}\n\n"
+        message += "Plex should detect both versions soon!"
+
+        self.send_notification(message)
+
+    def send_download_error(self, movie_title: str, error: str):
+        """Send notification about download error"""
+        message = f"❌ <b>Download Error</b>\n\n"
+        message += f"<b>Movie:</b> {movie_title}\n"
+        message += f"<b>Error:</b> {error}"
+
+        self.send_notification(message)
+
+    def test_connection(self) -> Dict[str, Any]:
+        """
+        Test Telegram bot connection
+
+        Returns:
+            Dict with success status and bot info
+        """
+        try:
+            url = f"{self.base_url}/getMe"
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+
+            result = response.json()
+            if result.get('ok'):
+                bot_info = result['result']
+                return {
+                    'success': True,
+                    'bot_username': bot_info.get('username'),
+                    'bot_name': bot_info.get('first_name'),
+                    'message': f"Connected to @{bot_info.get('username')}"
+                }
+            else:
+                return {'success': False, 'error': 'Bot API returned not ok'}
+
+        except Exception as e:
+            log.error(f"Telegram connection test failed: {e}")
+            return {'success': False, 'error': str(e)}
+
+    def cleanup_expired(self, max_age_hours: int = 24):
+        """
+        Clean up expired pending downloads
+
+        Args:
+            max_age_hours: Maximum age in hours before expiration
+        """
+        now = datetime.now()
+        expired = []
+
+        for message_id, pending in self.pending_downloads.items():
+            age = (now - pending['timestamp']).total_seconds() / 3600
+            if age > max_age_hours:
+                expired.append(message_id)
+
+        for message_id in expired:
+            pending = self.pending_downloads[message_id]
+            movie_title = pending['download_data'].get('movie_title', 'Unknown')
+            log.info(f"Expired pending download: {movie_title}")
+            del self.pending_downloads[message_id]
+
+        return len(expired)

--- a/integrations/upgrade_detector.py
+++ b/integrations/upgrade_detector.py
@@ -1,0 +1,276 @@
+"""
+Upgrade Detector
+
+Smart logic to determine if a new release is actually an upgrade worth notifying about.
+Prevents notification spam by only alerting on genuine quality improvements.
+"""
+
+import logging
+import re
+from typing import Dict, Tuple, Optional, Any
+
+log = logging.getLogger(__name__)
+
+
+class UpgradeDetector:
+    """Determines if a new release is a notification-worthy upgrade"""
+
+    def __init__(self, notification_config: Dict[str, Any]):
+        """
+        Initialize with notification preferences
+
+        Args:
+            notification_config: Dict of notification settings
+        """
+        self.config = notification_config
+
+    def is_notification_worthy(
+        self,
+        current_quality: Dict[str, Any],
+        new_quality: Dict[str, Any]
+    ) -> Tuple[bool, str]:
+        """
+        Determine if new release warrants notification
+
+        Args:
+            current_quality: Current movie quality details
+            new_quality: New release quality details
+
+        Returns:
+            (should_notify: bool, reason: str)
+        """
+        # Parse qualities
+        current = self.parse_quality(current_quality)
+        new = self.parse_quality(new_quality)
+
+        # Check for exact duplicate
+        if self.is_duplicate(current, new):
+            return False, "Already have this exact quality"
+
+        # Check FEL upgrade notifications
+        if self.config.get('notify_fel', True):
+            if new['is_fel']:
+                # New release is FEL
+                if current['is_fel']:
+                    # Already have FEL
+                    if not self.config.get('notify_fel_duplicates', False):
+                        return False, "Already have P7 FEL version"
+                    else:
+                        return True, "Additional P7 FEL copy (per settings)"
+                else:
+                    # Upgrade to FEL!
+                    if current['has_dv']:
+                        # Upgrade from lower DV profile to FEL
+                        if self.config.get('notify_fel_from_p5', True):
+                            return True, f"Upgrade: DV P{current['dv_profile']} → P7 FEL ⭐"
+                    else:
+                        # Upgrade from HDR10/SDR to FEL
+                        if self.config.get('notify_fel_from_hdr', True):
+                            return True, "Upgrade: HDR10/SDR → P7 FEL ⭐"
+
+        # Check general DV upgrade notifications
+        if self.config.get('notify_dv', False):
+            if new['has_dv'] and not current['has_dv']:
+                # Upgrade from no DV to DV
+                if self.config.get('notify_dv_from_hdr', True):
+                    return True, f"Upgrade: No DV → DV P{new['dv_profile']}"
+
+            if self.config.get('notify_dv_profile_upgrades', True):
+                if new['has_dv'] and current['has_dv']:
+                    # Both have DV, check for profile upgrade
+                    if new['dv_profile'] and current['dv_profile']:
+                        if new['dv_profile'] > current['dv_profile']:
+                            return True, f"Upgrade: DV P{current['dv_profile']} → P{new['dv_profile']}"
+
+        # Check Atmos upgrade notifications
+        if self.config.get('notify_atmos', False):
+            if new['has_atmos'] and not current['has_atmos']:
+                # New Atmos version
+                if self.config.get('notify_atmos_only_if_no_atmos', True):
+                    # Check if this is standalone Atmos or combo upgrade
+                    if new['has_dv'] and current['has_dv']:
+                        if new['dv_profile'] and current['dv_profile']:
+                            if new['dv_profile'] > current['dv_profile']:
+                                # Combo upgrade: better DV + Atmos
+                                if self.config.get('notify_atmos_with_dv_upgrade', True):
+                                    return True, f"Combo upgrade: DV P{current['dv_profile']} → P{new['dv_profile']} + Atmos 🎵"
+
+                    # Standalone Atmos addition
+                    return True, "Added: TrueHD Atmos 🎵"
+
+        # Check resolution upgrades
+        if self.config.get('notify_resolution', False):
+            if self.is_resolution_upgrade(current, new):
+                if self.config.get('notify_resolution_only_upgrades', True):
+                    return True, f"Upgrade: {current['resolution']} → {new['resolution']}"
+
+        # No notification criteria met
+        return False, "Not an upgrade per notification settings"
+
+    def parse_quality(self, quality_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Extract and normalize quality details
+
+        Args:
+            quality_data: Raw quality data from Plex/torrent
+
+        Returns:
+            Normalized quality dict
+        """
+        dv_profile = quality_data.get('dv_profile')
+        if dv_profile:
+            try:
+                dv_profile = int(dv_profile)
+            except (ValueError, TypeError):
+                dv_profile = None
+
+        return {
+            'has_dv': dv_profile is not None,
+            'dv_profile': dv_profile,
+            'is_fel': bool(quality_data.get('dv_fel', False) or quality_data.get('is_fel', False)),
+            'has_atmos': bool(quality_data.get('has_atmos', False)),
+            'resolution': quality_data.get('resolution', 'unknown').lower(),
+            'file_size': quality_data.get('file_size', 0),
+            'bitrate': quality_data.get('bitrate', 0)
+        }
+
+    def is_duplicate(self, current: Dict[str, Any], new: Dict[str, Any]) -> bool:
+        """
+        Check if new quality is exact duplicate of current
+
+        Args:
+            current: Parsed current quality
+            new: Parsed new quality
+
+        Returns:
+            True if duplicate
+        """
+        # Check DV profile match
+        if current['dv_profile'] != new['dv_profile']:
+            return False
+
+        # Check FEL status match
+        if current['is_fel'] != new['is_fel']:
+            return False
+
+        # Check Atmos match
+        if current['has_atmos'] != new['has_atmos']:
+            return False
+
+        # Check resolution match (fuzzy)
+        if not self._resolution_matches(current['resolution'], new['resolution']):
+            return False
+
+        return True
+
+    def is_resolution_upgrade(self, current: Dict[str, Any], new: Dict[str, Any]) -> bool:
+        """
+        Check if new resolution is better than current
+
+        Args:
+            current: Parsed current quality
+            new: Parsed new quality
+
+        Returns:
+            True if resolution upgrade
+        """
+        resolution_order = {
+            'unknown': 0,
+            'sd': 1,
+            '480p': 1,
+            '720p': 2,
+            'hd': 2,
+            '1080p': 3,
+            'full hd': 3,
+            'fhd': 3,
+            '2160p': 4,
+            '4k': 4,
+            'uhd': 4,
+            '8k': 5
+        }
+
+        current_res = current['resolution'].lower()
+        new_res = new['resolution'].lower()
+
+        current_value = resolution_order.get(current_res, 0)
+        new_value = resolution_order.get(new_res, 0)
+
+        return new_value > current_value
+
+    def _resolution_matches(self, res1: str, res2: str) -> bool:
+        """Check if two resolutions are equivalent"""
+        resolution_aliases = {
+            '720p': ['hd', '720p'],
+            '1080p': ['full hd', 'fhd', '1080p'],
+            '2160p': ['4k', 'uhd', '2160p', '4k uhd'],
+            '8k': ['8k', '4320p']
+        }
+
+        res1_lower = res1.lower()
+        res2_lower = res2.lower()
+
+        # Direct match
+        if res1_lower == res2_lower:
+            return True
+
+        # Check aliases
+        for canonical, aliases in resolution_aliases.items():
+            if res1_lower in aliases and res2_lower in aliases:
+                return True
+
+        return False
+
+    def parse_torrent_quality(self, torrent_title: str) -> Dict[str, Any]:
+        """
+        Parse quality information from torrent title
+
+        Args:
+            torrent_title: Torrent title string
+
+        Returns:
+            Quality dict suitable for parse_quality()
+        """
+        title_upper = torrent_title.upper()
+
+        quality = {
+            'dv_profile': None,
+            'is_fel': False,
+            'has_atmos': False,
+            'resolution': 'unknown'
+        }
+
+        # Check for DV Profile 7 FEL
+        if 'PROFILE 7' in title_upper or 'P7' in title_upper or 'PROFILE7' in title_upper:
+            quality['dv_profile'] = 7
+
+        # Check for FEL markers
+        if 'FEL' in title_upper or 'BL+EL' in title_upper or 'BL EL' in title_upper:
+            quality['is_fel'] = True
+            if not quality['dv_profile']:
+                # FEL implies Profile 7
+                quality['dv_profile'] = 7
+
+        # Check for other DV profiles
+        if not quality['dv_profile']:
+            profile_match = re.search(r'(?:PROFILE\s?|P)([58])', title_upper)
+            if profile_match:
+                quality['dv_profile'] = int(profile_match.group(1))
+            elif 'DOLBY VISION' in title_upper or 'DV' in title_upper or 'DOVI' in title_upper:
+                # Generic DV, assume Profile 5 (most common)
+                quality['dv_profile'] = 5
+
+        # Check for Atmos
+        if 'ATMOS' in title_upper or 'TRUEHD ATMOS' in title_upper:
+            quality['has_atmos'] = True
+
+        # Parse resolution
+        if '2160P' in title_upper or '4K' in title_upper or 'UHD' in title_upper:
+            quality['resolution'] = '2160p'
+        elif '1080P' in title_upper or 'FHD' in title_upper:
+            quality['resolution'] = '1080p'
+        elif '720P' in title_upper or 'HD' in title_upper:
+            quality['resolution'] = '720p'
+        elif '480P' in title_upper or 'SD' in title_upper:
+            quality['resolution'] = '480p'
+
+        return quality

--- a/metadata_service.py
+++ b/metadata_service.py
@@ -1,0 +1,704 @@
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree
+
+from plexapi.server import PlexServer
+
+log = logging.getLogger(__name__)
+
+
+def _utcnow_iso() -> str:
+    """Return current UTC time in ISO 8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_getattr(obj: Any, attr: str, default: Any = None) -> Any:
+    """Return attribute value if present, otherwise default."""
+    return getattr(obj, attr, default)
+
+
+class MetadataCache:
+    """Simple JSON-backed cache for movie metadata."""
+
+    def __init__(self, cache_path: str):
+        self._cache_path = cache_path
+        self._lock = threading.RLock()
+        self._data = self._load()
+
+    def _load(self) -> Dict[str, Any]:
+        if not os.path.exists(self._cache_path):
+            return {"_meta": {"last_summary_refresh": None}, "movies": {}}
+        try:
+            with open(self._cache_path, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+                if not isinstance(payload, dict):
+                    raise ValueError("Invalid cache format")
+        except Exception as exc:
+            log.warning("Failed to load metadata cache %s: %s", self._cache_path, exc)
+            return {"_meta": {"last_summary_refresh": None}, "movies": {}}
+
+        payload.setdefault("_meta", {}).setdefault("last_summary_refresh", None)
+        payload.setdefault("movies", {})
+        return payload
+
+    def _persist(self) -> None:
+        os.makedirs(os.path.dirname(self._cache_path), exist_ok=True)
+        tmp_path = f"{self._cache_path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            json.dump(self._data, handle, indent=2, sort_keys=True)
+        os.replace(tmp_path, self._cache_path)
+
+    def get_last_summary_refresh(self) -> Optional[str]:
+        with self._lock:
+            return self._data.get("_meta", {}).get("last_summary_refresh")
+
+    def set_last_summary_refresh(self, value: str) -> None:
+        with self._lock:
+            self._data.setdefault("_meta", {})["last_summary_refresh"] = value
+            self._persist()
+
+    def get_movie(self, rating_key: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            movie = self._data.get("movies", {}).get(str(rating_key))
+            if movie:
+                return json.loads(json.dumps(movie))
+            return None
+
+    def list_movies(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            movies = self._data.get("movies", {})
+            return [json.loads(json.dumps(movie)) for movie in movies.values()]
+
+    def upsert_movie(self, payload: Dict[str, Any]) -> None:
+        rating_key = str(payload.get("ratingKey"))
+        if not rating_key:
+            raise ValueError("Payload missing ratingKey")
+
+        with self._lock:
+            movies = self._data.setdefault("movies", {})
+            existing = movies.get(rating_key)
+            if existing:
+                payload = self._merge_movies(existing, payload)
+            movies[rating_key] = payload
+            self._persist()
+
+    def bulk_upsert(self, movies: List[Dict[str, Any]]) -> None:
+        with self._lock:
+            store = self._data.setdefault("movies", {})
+            for movie in movies:
+                key = str(movie.get("ratingKey"))
+                if not key:
+                    continue
+                existing = store.get(key)
+                if existing:
+                    movie = self._merge_movies(existing, movie)
+                store[key] = movie
+            self._persist()
+
+    @staticmethod
+    def _merge_movies(existing: Dict[str, Any], incoming: Dict[str, Any]) -> Dict[str, Any]:
+        merged = existing.copy()
+        merged.update({k: v for k, v in incoming.items() if k != "versions"})
+
+        existing_versions = existing.get("versions", [])
+        incoming_versions = incoming.get("versions", [])
+        merged["versions"] = MetadataCache._merge_versions(existing_versions, incoming_versions)
+
+        # Preserve detail metadata if the incoming payload does not include a refresh timestamp
+        detail_ts = incoming.get("detailRefreshedAt")
+        if not detail_ts and existing.get("detailRefreshedAt"):
+            merged["detailRefreshedAt"] = existing["detailRefreshedAt"]
+        return merged
+
+    @staticmethod
+    def _merge_versions(existing: List[Dict[str, Any]], incoming: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        by_id = {str(item.get("id")): item for item in existing if item.get("id") is not None}
+
+        merged_versions: List[Dict[str, Any]] = []
+        for version in incoming:
+            version_id = str(version.get("id"))
+            previous = by_id.get(version_id)
+            if previous:
+                merged_version = previous.copy()
+                merged_version.update({k: v for k, v in version.items() if k != "parts"})
+                merged_version["parts"] = MetadataCache._merge_parts(previous.get("parts", []), version.get("parts", []))
+            else:
+                merged_version = version
+            merged_versions.append(merged_version)
+        return merged_versions
+
+    @staticmethod
+    def _merge_parts(existing: List[Dict[str, Any]], incoming: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        by_id = {str(item.get("id")): item for item in existing if item.get("id") is not None}
+        merged_parts: List[Dict[str, Any]] = []
+        for part in incoming:
+            part_id = str(part.get("id"))
+            previous = by_id.get(part_id)
+            if previous:
+                merged_part = previous.copy()
+                merged_part.update(part)
+                if previous.get("ffprobe") and not part.get("ffprobe"):
+                    merged_part["ffprobe"] = previous["ffprobe"]
+                if previous.get("streamSummary") and not part.get("streamSummary"):
+                    merged_part["streamSummary"] = previous["streamSummary"]
+            else:
+                merged_part = part
+            merged_parts.append(merged_part)
+        return merged_parts
+
+
+class MetadataService:
+    """Fetch and cache metadata for Plex movies, including ffprobe analysis."""
+
+    def __init__(
+        self,
+        cache_path: str,
+        plex_url: Optional[str] = None,
+        plex_token: Optional[str] = None,
+        library_name: Optional[str] = None,
+        ffprobe_path: Optional[str] = None,
+        summary_ttl_seconds: int = 3600,
+        ffprobe_timeout: int = 30,
+    ):
+        self._cache = MetadataCache(cache_path)
+        self._plex_url = plex_url
+        self._plex_token = plex_token
+        self._library_name = library_name
+        self._ffprobe_path = ffprobe_path or "ffprobe"
+        self._summary_ttl_seconds = summary_ttl_seconds
+        self._ffprobe_timeout = ffprobe_timeout
+
+        self._plex: Optional[PlexServer] = None
+        self._plex_lock = threading.RLock()
+
+    # Configuration management -------------------------------------------------
+
+    def update_config(
+        self,
+        plex_url: Optional[str],
+        plex_token: Optional[str],
+        library_name: Optional[str],
+        ffprobe_path: Optional[str] = None,
+    ) -> None:
+        with self._plex_lock:
+            config_changed = (plex_url != self._plex_url) or (plex_token != self._plex_token)
+            self._plex_url = plex_url
+            self._plex_token = plex_token
+            self._library_name = library_name
+            if ffprobe_path:
+                self._ffprobe_path = ffprobe_path
+            if config_changed:
+                self._plex = None
+
+    def is_configured(self) -> bool:
+        return bool(self._plex_url and self._plex_token and self._library_name)
+
+    @property
+    def ffprobe_path(self) -> str:
+        return self._ffprobe_path
+
+    # Public API ----------------------------------------------------------------
+
+    def list_movies(self, force_refresh: bool = False) -> List[Dict[str, Any]]:
+        """Return cached movie summaries, refreshing from Plex when needed."""
+        if force_refresh or self._summary_cache_expired():
+            try:
+                summaries = self._fetch_library_summaries()
+                self._cache.bulk_upsert(summaries)
+                self._cache.set_last_summary_refresh(_utcnow_iso())
+            except Exception as exc:
+                log.error("Failed to refresh Plex metadata summaries: %s", exc, exc_info=True)
+        return self._cache.list_movies()
+
+    def summary_refreshed_at(self) -> Optional[str]:
+        return self._cache.get_last_summary_refresh()
+
+    def get_movie(self, rating_key: str, refresh: bool = False) -> Optional[Dict[str, Any]]:
+        """Return metadata for a specific movie, optionally refreshing."""
+        if refresh:
+            try:
+                movie = self._fetch_movie_detail(rating_key)
+                self._cache.upsert_movie(movie)
+                return movie
+            except Exception as exc:
+                log.error("Failed to refresh metadata for ratingKey %s: %s", rating_key, exc, exc_info=True)
+                cached = self._cache.get_movie(rating_key) or {}
+                cached["detailError"] = str(exc)
+                cached["detailRefreshedAt"] = _utcnow_iso()
+                self._cache.upsert_movie(cached)
+                return cached
+
+        cached_movie = self._cache.get_movie(rating_key)
+        if cached_movie:
+            return cached_movie
+
+        try:
+            movie = self._fetch_movie_detail(rating_key)
+            self._cache.upsert_movie(movie)
+            return movie
+        except Exception as exc:
+            log.error("Unable to fetch metadata for ratingKey %s: %s", rating_key, exc, exc_info=True)
+            return None
+
+    # Internal helpers ---------------------------------------------------------
+
+    def _summary_cache_expired(self) -> bool:
+        ts = self._cache.get_last_summary_refresh()
+        if not ts:
+            return True
+        try:
+            last = datetime.fromisoformat(ts)
+        except ValueError:
+            return True
+        delta = datetime.now(timezone.utc) - last
+        return delta.total_seconds() > self._summary_ttl_seconds
+
+    def _fetch_library_summaries(self) -> List[Dict[str, Any]]:
+        library = self._get_library()
+        movies = []
+        for movie in library.all():
+            try:
+                movies.append(self._normalize_movie(movie, include_ffprobe=False))
+            except Exception as exc:
+                log.warning("Failed to normalize movie %s (%s): %s", getattr(movie, "title", "unknown"), getattr(movie, "ratingKey", "?"), exc)
+        return movies
+
+    def _fetch_movie_detail(self, rating_key: str) -> Dict[str, Any]:
+        plex = self._get_plex()
+        if not plex:
+            raise RuntimeError("Plex is not configured")
+        item = plex.fetchItem(int(rating_key) if str(rating_key).isdigit() else rating_key)
+        return self._normalize_movie(item, include_ffprobe=True)
+
+    def _get_plex(self) -> Optional[PlexServer]:
+        if not self._plex_url or not self._plex_token:
+            return None
+        with self._plex_lock:
+            if self._plex is None:
+                log.info("Connecting to Plex at %s", self._plex_url)
+                self._plex = PlexServer(self._plex_url, self._plex_token)
+        return self._plex
+
+    def _get_library(self):
+        plex = self._get_plex()
+        if not plex:
+            raise RuntimeError("Plex is not configured")
+        if not self._library_name:
+            raise RuntimeError("Plex library name is not configured")
+        return plex.library.section(self._library_name)
+
+    def _normalize_movie(self, movie, include_ffprobe: bool) -> Dict[str, Any]:
+        stream_lookup: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+        if include_ffprobe:
+            stream_lookup = self._fetch_streams_map(movie)
+
+        payload: Dict[str, Any] = {
+            "ratingKey": _safe_getattr(movie, "ratingKey"),
+            "title": _safe_getattr(movie, "title"),
+            "year": _safe_getattr(movie, "year"),
+            "summary": _safe_getattr(movie, "summary"),
+            "thumb": _safe_getattr(movie, "thumb"),
+            "art": _safe_getattr(movie, "art"),
+            "guid": _safe_getattr(movie, "guid"),
+            "studio": _safe_getattr(movie, "studio"),
+            "tagline": _safe_getattr(movie, "tagline"),
+            "genres": [g.tag for g in _safe_getattr(movie, "genres", []) if getattr(g, "tag", None)],
+            "collections": [c.tag for c in _safe_getattr(movie, "collections", []) if getattr(c, "tag", None)],
+            "addedAt": self._datetime_to_iso(_safe_getattr(movie, "addedAt")),
+            "updatedAt": self._datetime_to_iso(_safe_getattr(movie, "updatedAt")),
+            "summaryRefreshedAt": _utcnow_iso(),
+        }
+
+        versions = []
+        for media in _safe_getattr(movie, "media", []):
+            version = {
+                "id": _safe_getattr(media, "id"),
+                "duration": _safe_getattr(media, "duration"),
+                "bitrate": _safe_getattr(media, "bitrate"),
+                "container": _safe_getattr(media, "container"),
+                "videoResolution": _safe_getattr(media, "videoResolution"),
+                "videoCodec": _safe_getattr(media, "videoCodec"),
+                "audioCodec": _safe_getattr(media, "audioCodec"),
+                "audioChannels": _safe_getattr(media, "audioChannels"),
+                "height": _safe_getattr(media, "height"),
+                "width": _safe_getattr(media, "width"),
+                "aspectRatio": _safe_getattr(media, "aspectRatio"),
+                "parts": [],
+            }
+            media_streams = stream_lookup.get(str(version["id"])) if stream_lookup else None
+            for part in _safe_getattr(media, "parts", []):
+                version["parts"].append(self._normalize_part(part, include_ffprobe, media_streams))
+            versions.append(version)
+
+        for version in versions:
+            self._summarize_version_features(version)
+
+        payload["versions"] = versions
+        if include_ffprobe:
+            payload["detailRefreshedAt"] = _utcnow_iso()
+        return payload
+
+    def _normalize_part(
+        self,
+        part,
+        include_ffprobe: bool,
+        media_streams: Optional[Dict[str, List[Dict[str, Any]]]] = None,
+    ) -> Dict[str, Any]:
+        normalized = {
+            "id": _safe_getattr(part, "id"),
+            "file": _safe_getattr(part, "file"),
+            "size": _safe_getattr(part, "size"),
+            "duration": _safe_getattr(part, "duration"),
+            "container": _safe_getattr(part, "container"),
+            "accessedAt": self._datetime_to_iso(_safe_getattr(part, "accessedAt")),
+            "exists": _safe_getattr(part, "exists"),
+            "streamSummary": None,
+            "ffprobe": None,
+            "ffprobeError": None,
+            "plexStreams": [],
+        }
+
+        if media_streams:
+            part_streams = media_streams.get(str(normalized["id"]))
+            if part_streams:
+                normalized["plexStreams"] = part_streams
+
+        if include_ffprobe and normalized.get("file"):
+            try:
+                probe = self._run_ffprobe(normalized["file"])
+                normalized["ffprobe"] = probe
+                normalized["streamSummary"] = self._summarize_streams(probe)
+            except Exception as exc:
+                normalized["ffprobeError"] = str(exc)
+        return normalized
+
+    def _run_ffprobe(self, file_path: str) -> Dict[str, Any]:
+        import subprocess
+
+        cmd = [
+            self._ffprobe_path,
+            "-v",
+            "error",
+            "-show_format",
+            "-show_streams",
+            "-print_format",
+            "json",
+            file_path,
+        ]
+        start = time.time()
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            text=True,
+            timeout=self._ffprobe_timeout,
+        )
+        duration = time.time() - start
+        if result.returncode != 0:
+            raise RuntimeError(f"ffprobe failed ({result.returncode}) after {duration:.1f}s: {result.stderr.strip()}")
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Unable to parse ffprobe output: {exc}") from exc
+
+    def _summarize_streams(self, probe: Dict[str, Any]) -> Dict[str, Any]:
+        streams = probe.get("streams", [])
+        format_info = probe.get("format", {})
+
+        video_streams = []
+        audio_streams = []
+        subtitle_streams = []
+
+        for stream in streams:
+            codec_type = stream.get("codec_type")
+            base = {
+                "id": stream.get("index"),
+                "codec": stream.get("codec_name"),
+                "codecLong": stream.get("codec_long_name"),
+                "language": stream.get("tags", {}).get("language"),
+                "title": stream.get("tags", {}).get("title"),
+            }
+            if codec_type == "video":
+                video_streams.append(
+                    {
+                        **base,
+                        "width": stream.get("width"),
+                        "height": stream.get("height"),
+                        "profile": stream.get("profile"),
+                        "pixFmt": stream.get("pix_fmt"),
+                        "colorPrimaries": stream.get("color_primaries"),
+                        "colorTransfer": stream.get("color_transfer"),
+                        "colorSpace": stream.get("color_space"),
+                        "bitDepth": stream.get("bits_per_raw_sample") or stream.get("bits_per_sample"),
+                    }
+                )
+            elif codec_type == "audio":
+                audio_streams.append(
+                    {
+                        **base,
+                        "channels": stream.get("channels"),
+                        "channelLayout": stream.get("channel_layout"),
+                        "sampleRate": stream.get("sample_rate"),
+                        "bitRate": stream.get("bit_rate") or format_info.get("bit_rate"),
+                    }
+                )
+            elif codec_type in ("subtitle", "text"):
+                subtitle_streams.append(
+                    {
+                        **base,
+                        "hearingImpaired": stream.get("disposition", {}).get("hearing_impaired") == 1,
+                        "forced": stream.get("disposition", {}).get("forced") == 1,
+                    }
+                )
+
+        return {
+            "format": {
+                "filename": format_info.get("filename"),
+                "duration": format_info.get("duration"),
+                "size": format_info.get("size"),
+                "bitRate": format_info.get("bit_rate"),
+                "tags": format_info.get("tags", {}),
+            },
+            "video": video_streams,
+            "audio": audio_streams,
+            "subtitles": subtitle_streams,
+        }
+
+    @staticmethod
+    def _datetime_to_iso(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return value.astimezone(timezone.utc).isoformat()
+        return str(value)
+
+    def _fetch_streams_map(self, movie) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+        plex = self._get_plex()
+        if not plex:
+            return {}
+
+        try:
+            element = plex._server.query(f"{movie.key}?checkFiles=1&includeAllStreams=1")
+        except Exception as exc:
+            log.debug("Failed to fetch stream XML for %s: %s", getattr(movie, "ratingKey", "?"), exc)
+            return {}
+
+        stream_map: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+        for video_el in element.iter("Video"):
+            for media_el in video_el.findall("Media"):
+                media_id = media_el.get("id")
+                if not media_id:
+                    continue
+                part_map: Dict[str, List[Dict[str, Any]]] = {}
+                for part_el in media_el.findall("Part"):
+                    part_id = part_el.get("id")
+                    if not part_id:
+                        continue
+                    streams = [self._normalize_stream_xml(stream_el) for stream_el in part_el.findall("Stream")]
+                    part_map[part_id] = streams
+                if part_map:
+                    stream_map[media_id] = part_map
+        return stream_map
+
+    @staticmethod
+    def _normalize_stream_xml(stream_el: ElementTree.Element) -> Dict[str, Any]:
+        stream_type_map = {
+            "1": "video",
+            "2": "audio",
+            "3": "subtitle",
+            "4": "lyrics",
+        }
+        stream_type = stream_el.get("streamType")
+        data: Dict[str, Any] = {
+            "id": stream_el.get("id"),
+            "type": stream_type_map.get(stream_type, stream_type),
+            "codec": stream_el.get("codec"),
+            "profile": stream_el.get("profile"),
+            "displayTitle": stream_el.get("displayTitle"),
+            "extendedDisplayTitle": stream_el.get("extendedDisplayTitle"),
+            "language": stream_el.get("language") or stream_el.get("languageTag"),
+            "languageCode": stream_el.get("languageCode"),
+            "channels": stream_el.get("channels"),
+            "audioChannelLayout": stream_el.get("audioChannelLayout"),
+            "bitDepth": stream_el.get("bitDepth"),
+            "bitrate": stream_el.get("bitrate"),
+            "frameRate": stream_el.get("frameRate"),
+            "width": stream_el.get("width"),
+            "height": stream_el.get("height"),
+            "hdr": stream_el.get("hdr"),
+            "colorSpace": stream_el.get("colorSpace"),
+            "colorTrc": stream_el.get("colorTrc"),
+            "colorPrimaries": stream_el.get("colorPrimaries"),
+            "colorRange": stream_el.get("colorRange"),
+            "title": stream_el.get("title"),
+            "forced": stream_el.get("forced") == "1",
+            "hearingImpaired": stream_el.get("hearingImpaired") == "1",
+        }
+
+        if stream_type == "1":  # video
+            dolby_present = stream_el.get("DOVIPresent") == "1"
+            data["dolbyVision"] = {
+                "present": dolby_present,
+                "profile": stream_el.get("DOVIProfile"),
+                "level": stream_el.get("DOVILevel"),
+                "version": stream_el.get("DOVIVersion"),
+                "rpu": stream_el.get("DOVIRPUPresent") == "1" if stream_el.get("DOVIRPUPresent") else None,
+                "bl": stream_el.get("DOVIBLPresent") == "1" if stream_el.get("DOVIBLPresent") else None,
+                "el": stream_el.get("DOVIELPresent") == "1" if stream_el.get("DOVIELPresent") else None,
+            }
+            data["dynamicRange"] = stream_el.get("hdr") or ("Dolby Vision" if dolby_present else None)
+        return {k: v for k, v in data.items() if v not in (None, "", [])}
+
+    def _summarize_version_features(self, version: Dict[str, Any]) -> None:
+        parts = version.get("parts", [])
+        if not any(part.get("plexStreams") for part in parts):
+            return
+
+        video_streams: List[Dict[str, Any]] = []
+        audio_streams: List[Dict[str, Any]] = []
+        subtitle_streams: List[Dict[str, Any]] = []
+
+        for part in parts:
+            for stream in part.get("plexStreams", []):
+                stream_type = stream.get("type")
+                if stream_type == "video":
+                    video_streams.append(stream)
+                elif stream_type == "audio":
+                    audio_streams.append(stream)
+                elif stream_type == "subtitle":
+                    subtitle_streams.append(stream)
+
+        prefer_video = video_streams[0] if video_streams else {}
+        dynamic_range = prefer_video.get("dynamicRange")
+        if not dynamic_range and prefer_video.get("dolbyVision", {}).get("present"):
+            dynamic_range = "Dolby Vision"
+        elif not dynamic_range and prefer_video.get("hdr"):
+            dynamic_range = prefer_video.get("hdr")
+
+        resolution_label = None
+        resolution_rank = 0
+        width = version.get("width") or prefer_video.get("width")
+        height = version.get("height") or prefer_video.get("height")
+        if version.get("videoResolution"):
+            res = str(version["videoResolution"]).lower()
+            if res in {"4k", "uhd", "2160", "2160p"}:
+                resolution_label = "4K"
+                resolution_rank = 3
+            elif res in {"1080", "1080p"}:
+                resolution_label = "1080p"
+                resolution_rank = 2
+            elif res in {"720", "720p"}:
+                resolution_label = "720p"
+                resolution_rank = 1
+            else:
+                resolution_label = version["videoResolution"]
+        if width or height:
+            w = int(width or 0)
+            h = int(height or 0)
+            if w >= 3000 or h >= 1700:
+                resolution_label = resolution_label or "4K"
+                resolution_rank = max(resolution_rank, 3)
+            elif w >= 1700 or h >= 900:
+                if not resolution_label or resolution_label == "4K":
+                    resolution_label = resolution_label or "1080p"
+                resolution_rank = max(resolution_rank, 2)
+            elif w >= 1200 or h >= 700:
+                if not resolution_label:
+                    resolution_label = "720p"
+                resolution_rank = max(resolution_rank, 1)
+
+        dolby = prefer_video.get("dolbyVision", {})
+        has_dv = bool(dolby.get("present"))
+        dv_profile = dolby.get("profile")
+        dv_level = dolby.get("level")
+        has_dv_fel = bool(dolby.get("el"))
+
+        audio_formats = []
+        has_atmos = False
+        for stream in audio_streams:
+            display = stream.get("extendedDisplayTitle") or stream.get("displayTitle")
+            if display:
+                audio_formats.append(display)
+                if "atmos" in display.lower():
+                    has_atmos = True
+            title = stream.get("title") or ""
+            if "atmos" in title.lower():
+                has_atmos = True
+
+        subtitle_languages = list(
+            dict.fromkeys(
+                [
+                    stream.get("language") or stream.get("languageCode")
+                    for stream in subtitle_streams
+                    if (stream.get("language") or stream.get("languageCode"))
+                ]
+            )
+        )
+        subtitle_summary = subtitle_languages[:4]
+        subtitle_extra = max(len(subtitle_languages) - len(subtitle_summary), 0)
+
+        features = {
+            "hasDolbyVision": has_dv,
+            "dolbyVisionProfile": dv_profile,
+            "dolbyVisionLevel": dv_level,
+            "dolbyVisionIsProfile7": bool(dv_profile) and dv_profile.strip() == "7",
+            "dolbyVisionHasFEL": has_dv_fel,
+            "dolbyVisionLabel": f"P{dv_profile} · L{dv_level}" if dv_profile and dv_level else None,
+            "dynamicRange": dynamic_range,
+            "bitDepth": prefer_video.get("bitDepth"),
+            "colorSpace": prefer_video.get("colorSpace"),
+            "colorTrc": prefer_video.get("colorTrc"),
+            "colorPrimaries": prefer_video.get("colorPrimaries"),
+            "hasAtmos": has_atmos,
+            "audioFormats": audio_formats,
+            "subtitleLanguages": subtitle_languages,
+            "subtitleSummary": subtitle_summary,
+            "subtitleExtraCount": subtitle_extra,
+            "resolutionLabel": resolution_label,
+            "videoCodec": version.get("videoCodec"),
+            "audioCodec": version.get("audioCodec"),
+            "resolutionRank": resolution_rank,
+        }
+
+        if has_dv:
+            if features["dolbyVisionIsProfile7"]:
+                if has_dv_fel:
+                    features["dolbyVisionSummary"] = "Dolby Vision · Profile 7 FEL"
+                else:
+                    features["dolbyVisionSummary"] = "Dolby Vision · Profile 7"
+            else:
+                profile_label = f"Profile {dv_profile}" if dv_profile else None
+                features["dolbyVisionSummary"] = "Dolby Vision" + (f" · {profile_label}" if profile_label else "")
+
+        version["features"] = {k: v for k, v in features.items() if v not in (None, "", [])}
+        tags = []
+        if has_dv:
+            if features.get("dolbyVisionIsProfile7"):
+                if has_dv_fel:
+                    tags.append("DoVi P7 FEL")
+                else:
+                    tags.append("DoVi P7")
+            else:
+                tags.append("Dolby Vision")
+        elif dynamic_range:
+            tags.append(dynamic_range)
+        if resolution_label:
+            tags.append(resolution_label)
+        if has_atmos:
+            tags.append("Atmos")
+        if version.get("audioChannels"):
+            tags.append(f"{version['audioChannels']}ch")
+        if subtitle_summary:
+            tag_text = ", ".join(subtitle_summary)
+            if subtitle_extra:
+                tag_text += f" +{subtitle_extra} more"
+            tags.append(f"Subs: {tag_text}")
+        version["summaryTags"] = tags

--- a/sofarclaude.txt
+++ b/sofarclaude.txt
@@ -1,0 +1,963 @@
+================================================================================
+FELSCANNER RADARR + QBITTORRENT INTEGRATION - COMPREHENSIVE DOCUMENTATION
+================================================================================
+Date: 2025-10-09
+Status: Core modules complete, integration with app.py pending
+
+================================================================================
+PROJECT GOAL
+================================================================================
+
+Build an interactive download approval system that allows FELScanner to:
+
+1. Monitor IPTorrents for new Dolby Vision Profile 7 FEL releases
+2. Check if the user already has that movie (and what quality)
+3. Send a Telegram notification with interactive buttons ONLY if it's an upgrade
+4. Wait for user approval via Telegram (✅ Download or ❌ Skip)
+5. If approved, send the torrent directly to qBittorrent
+6. Download to the SAME FOLDER as the existing movie file
+7. Let Plex auto-detect both versions and stack them (Plex "Play Version" menu)
+8. Radarr manages both files, no multiple Radarr instances needed
+
+KEY USER REQUIREMENTS:
+- NO auto-download - always require approval
+- Send Telegram notification ONLY for actual upgrades:
+  * ✅ Have DV P5 → New P7 FEL available = NOTIFY
+  * ❌ Have DV P7 FEL → Another P7 FEL = DON'T NOTIFY (skip silently)
+  * ✅ Have HDR10 → New DV P7 FEL = NOTIFY
+  * ✅ Have no Atmos → New Atmos + better DV = NOTIFY
+- Show current quality vs. new quality in Telegram message
+- Settings should be a dedicated page (too many options for modal now)
+- qBittorrent is at 10.0.0.63:8080 with no auth (same LAN)
+- Radarr root path: /mnt/user/Media/Movies/ (same as host path)
+
+================================================================================
+ARCHITECTURE OVERVIEW
+================================================================================
+
+NEW MODULES CREATED (integrations/ directory):
+
+1. qbittorrent.py - QBittorrentClient
+   - Communicates with qBittorrent Web API
+   - Adds torrents to specific folders
+   - Monitors torrent progress
+   - No authentication support (for LAN use)
+
+2. radarr.py - RadarrClient
+   - Communicates with Radarr API v3
+   - Searches for movies by title/year
+   - Gets folder paths where movies are stored
+   - Gets current movie file info (quality, resolution, size)
+
+3. upgrade_detector.py - UpgradeDetector
+   - Smart notification filtering logic
+   - Determines if new release is actually an upgrade
+   - Prevents spam by checking:
+     * Already have exact same quality? → Skip
+     * Already have P7 FEL and new is P7 FEL? → Skip (unless user enables duplicates)
+     * Have P5 and new is P7 FEL? → Notify (upgrade!)
+     * Have HDR10 and new is any DV? → Notify (upgrade!)
+   - Parses quality from torrent titles
+   - Configurable notification rules
+
+4. telegram_handler.py - TelegramDownloadHandler
+   - Sends interactive approval requests
+   - Creates inline keyboards with ✅ Download / ❌ Skip buttons
+   - Formats messages with current vs. new quality comparison
+   - Handles callback button presses from user
+   - Updates messages after approval/decline
+   - Tracks pending downloads by message ID
+   - Auto-expires old requests (configurable, default 24h)
+
+5. download_manager.py - DownloadManager
+   - Orchestrates the complete workflow
+   - Entry point: process_ipt_discovery()
+   - Steps:
+     a. Parse torrent title → extract movie name, year, quality
+     b. Look up movie in Plex database
+     c. Get current quality from database
+     d. Call upgrade_detector → should we notify?
+     e. If yes, get Radarr folder path
+     f. Build download request with all details
+     g. Store in database (pending_downloads table)
+     h. Send Telegram approval request
+     i. Wait for user response (async via Telegram callback)
+   - Entry point: execute_download()
+     j. Get download request from database
+     k. Send torrent to qBittorrent with correct folder path
+     l. Track download in database
+     m. Send Telegram confirmation
+
+DATABASE SCHEMA ADDITIONS (scanner.py - MovieDatabase class):
+
+New Tables:
+
+1. pending_downloads
+   - request_id TEXT PRIMARY KEY
+   - movie_title TEXT
+   - year INTEGER
+   - torrent_url TEXT (magnet link or torrent URL)
+   - target_folder TEXT (from Radarr)
+   - quality_type TEXT (fel, dv, hdr)
+   - status TEXT (pending, downloading, completed, declined)
+   - telegram_message_id INTEGER
+   - download_data TEXT (JSON blob with all details)
+   - created_at TEXT
+   - expires_at TEXT
+   - approved_at TEXT
+   - completed_at TEXT
+
+2. download_history
+   - id INTEGER PRIMARY KEY AUTOINCREMENT
+   - request_id TEXT
+   - movie_title TEXT
+   - quality_type TEXT
+   - torrent_hash TEXT (from qBittorrent)
+   - status TEXT (downloading, completed, failed)
+   - started_at TEXT
+   - completed_at TEXT
+
+New Methods in MovieDatabase:
+- store_pending_download()
+- get_pending_download()
+- get_all_pending_downloads()
+- mark_download_started()
+- mark_download_completed()
+- delete_pending_download()
+- get_download_history()
+
+================================================================================
+WHAT'S BEEN COMPLETED (✅)
+================================================================================
+
+1. INTEGRATIONS DIRECTORY STRUCTURE
+   ✅ Created integrations/__init__.py
+   ✅ All modules properly exported
+
+2. QBITTORRENT CLIENT (250 lines)
+   ✅ Full Web API v2 implementation
+   ✅ add_torrent(url_or_magnet, save_path, category, paused, sequential)
+   ✅ get_torrents(category, filter_status)
+   ✅ get_torrent_info(hash)
+   ✅ test_connection() - returns version, torrent count
+   ✅ get_categories()
+   ✅ Authentication support (optional for LAN mode)
+   ✅ Session management with cookies
+
+3. RADARR CLIENT (220 lines)
+   ✅ Full API v3 implementation
+   ✅ get_movies() - fetch all movies
+   ✅ search_movie(title, year) - find specific movie
+   ✅ get_movie_by_id(radarr_id)
+   ✅ get_movie_folder(title, year) - returns folder path string
+   ✅ get_movie_file_info(title, year) - returns quality details
+   ✅ test_connection() - returns version, movie count
+   ✅ get_root_folders()
+   ✅ get_quality_profiles()
+
+4. UPGRADE DETECTOR (280 lines)
+   ✅ parse_quality() - extracts DV profile, FEL status, Atmos, resolution
+   ✅ is_notification_worthy(current, new) - main decision logic
+   ✅ is_duplicate() - checks if exact same quality
+   ✅ is_resolution_upgrade() - 1080p → 2160p detection
+   ✅ parse_torrent_quality() - extracts quality from torrent title
+   ✅ Configurable notification rules:
+      - notify_fel (default: true)
+      - notify_fel_from_p5 (default: true)
+      - notify_fel_from_hdr (default: true)
+      - notify_fel_duplicates (default: false) ← KEY SETTING
+      - notify_dv (default: false)
+      - notify_dv_from_hdr (default: true)
+      - notify_dv_profile_upgrades (default: true)
+      - notify_atmos (default: false)
+      - notify_atmos_only_if_no_atmos (default: true)
+      - notify_atmos_with_dv_upgrade (default: true)
+      - notify_resolution (default: false)
+      - notify_resolution_only_upgrades (default: true)
+
+5. TELEGRAM HANDLER (340 lines)
+   ✅ send_approval_request(download_request) - sends interactive message
+   ✅ Creates inline keyboard with ✅ Download / ❌ Skip buttons
+   ✅ Formats message with HTML:
+      - Movie title & year
+      - Current quality (DV profile, size, bitrate, Atmos)
+      - New quality (what's available)
+      - Upgrade reason
+      - Target folder
+   ✅ handle_callback(callback_data, message_id, chat_id) - processes button press
+   ✅ Parses callback data: "dl_yes_abc123" or "dl_no_abc123"
+   ✅ Updates message text after response
+   ✅ Answers callback query (stops loading animation)
+   ✅ send_notification() - simple messages
+   ✅ send_download_started()
+   ✅ send_download_completed()
+   ✅ send_download_error()
+   ✅ test_connection() - returns bot username/name
+   ✅ cleanup_expired() - removes old pending downloads
+
+6. DOWNLOAD MANAGER (420 lines)
+   ✅ process_ipt_discovery(torrent_data) - main workflow
+      - Parses torrent title
+      - Finds movie in database
+      - Gets current quality
+      - Calls upgrade detector
+      - Gets Radarr folder
+      - Stores pending download
+      - Sends Telegram approval
+   ✅ execute_download(request_id, action) - executes approved download
+      - Retrieves download data
+      - Sends to qBittorrent
+      - Updates database
+      - Sends notifications
+   ✅ parse_torrent_title() - extracts movie name & year
+   ✅ find_movie_in_db() - queries Plex database
+   ✅ get_current_quality() - formats current movie quality
+   ✅ format_current_quality() - for Telegram display
+   ✅ format_new_quality() - for Telegram display
+   ✅ generate_request_id() - MD5 hash-based unique ID
+   ✅ Database method delegates (store, get, mark)
+
+7. DATABASE SCHEMA (140 lines added to scanner.py)
+   ✅ pending_downloads table created
+   ✅ download_history table created
+   ✅ Indices for performance (status, created_at, movie_title)
+   ✅ All CRUD methods implemented in MovieDatabase class
+   ✅ JSON serialization for download_data blob
+   ✅ Proper timestamp tracking
+
+TOTAL CODE WRITTEN: ~1,850 lines of production-ready Python
+
+================================================================================
+WHAT NEEDS TO BE DONE (📋)
+================================================================================
+
+1. WIRE INTO APP.PY (HIGH PRIORITY)
+
+   Need to add:
+
+   A. Initialize integration clients on app startup:
+      ```python
+      from integrations import (
+          QBittorrentClient,
+          RadarrClient,
+          UpgradeDetector,
+          TelegramDownloadHandler,
+          DownloadManager
+      )
+
+      # Initialize clients (after config loaded)
+      qbt_client = QBittorrentClient(
+          host=app.config.get('QBITTORRENT_HOST', '10.0.0.63'),
+          port=app.config.get('QBITTORRENT_PORT', 8080),
+          username=app.config.get('QBITTORRENT_USERNAME', ''),
+          password=app.config.get('QBITTORRENT_PASSWORD', '')
+      )
+
+      radarr_client = RadarrClient(
+          base_url=app.config.get('RADARR_URL', ''),
+          api_key=app.config.get('RADARR_API_KEY', '')
+      )
+
+      telegram_handler = TelegramDownloadHandler(
+          bot_token=app.config.get('TELEGRAM_TOKEN', ''),
+          chat_id=app.config.get('TELEGRAM_CHAT_ID', '')
+      )
+
+      upgrade_detector = UpgradeDetector(
+          notification_config={
+              'notify_fel': app.config.get('NOTIFY_FEL', True),
+              'notify_fel_from_p5': app.config.get('NOTIFY_FEL_FROM_P5', True),
+              'notify_fel_from_hdr': app.config.get('NOTIFY_FEL_FROM_HDR', True),
+              'notify_fel_duplicates': app.config.get('NOTIFY_FEL_DUPLICATES', False),
+              # ... all other notification settings
+          }
+      )
+
+      download_manager = DownloadManager(
+          qbt_client=qbt_client,
+          radarr_client=radarr_client,
+          telegram_handler=telegram_handler,
+          upgrade_detector=upgrade_detector,
+          scanner_db=state.scanner_obj.db  # Existing scanner database
+      )
+      ```
+
+   B. Add connection monitoring to AppState class:
+      ```python
+      self.connection_status = {
+          'plex': {...},
+          'telegram': {...},
+          'iptorrents': {...},
+          'radarr': {'status': 'unknown', 'message': 'Not connected', ...},
+          'qbittorrent': {'status': 'unknown', 'message': 'Not connected', ...}
+      }
+      ```
+
+   C. Add APScheduler health checks (in init_connection_checks):
+      ```python
+      async def check_radarr_connection():
+          result = await radarr_client.test_connection()
+          state.connection_status['radarr'] = {
+              'status': 'connected' if result['success'] else 'error',
+              'message': result.get('message', result.get('error')),
+              'last_check': datetime.now(timezone.utc),
+              'movie_count': result.get('movie_count')
+          }
+
+      async def check_qbittorrent_connection():
+          result = await qbt_client.test_connection()
+          state.connection_status['qbittorrent'] = {
+              'status': 'connected' if result['success'] else 'error',
+              'message': result.get('message', result.get('error')),
+              'last_check': datetime.now(timezone.utc),
+              'torrent_count': result.get('torrent_count')
+          }
+
+      # Schedule checks
+      scheduler.add_job(
+          run_async_job, 'interval', minutes=15,
+          args=[check_radarr_connection], id='check_radarr'
+      )
+      scheduler.add_job(
+          run_async_job, 'interval', minutes=15,
+          args=[check_qbittorrent_connection], id='check_qbit'
+      )
+      ```
+
+   D. Hook into IPT scanner callback:
+      Find where IPT scanner processes new torrents (likely in run_ipt_scanner()
+      or monitor-iptorrents.js callback) and add:
+      ```python
+      # When new FEL torrents found
+      for torrent in new_fel_torrents:
+          result = await download_manager.process_ipt_discovery({
+              'title': torrent['title'],
+              'url': torrent.get('url'),
+              'magnet_link': torrent.get('magnet_link'),
+              'size': torrent.get('size'),
+              'seeders': torrent.get('seeders')
+          })
+
+          app.logger.info(f"IPT discovery result: {result['status']} - {torrent['title']}")
+      ```
+
+   E. Add Telegram webhook endpoint:
+      ```python
+      @app.route('/telegram/webhook', methods=['POST'])
+      def telegram_webhook():
+          """Handle Telegram callback button presses"""
+          data = request.get_json()
+
+          if 'callback_query' in data:
+              callback_query = data['callback_query']
+              callback_data = callback_query['data']
+              message_id = callback_query['message']['message_id']
+              chat_id = callback_query['message']['chat']['id']
+              callback_query_id = callback_query['id']
+
+              # Handle callback
+              result = telegram_handler.handle_callback(
+                  callback_data, message_id, chat_id
+              )
+
+              # Answer callback query
+              telegram_handler._answer_callback_query(
+                  callback_query_id,
+                  "Processing..." if result['success'] else "Error"
+              )
+
+              # If approved, execute download
+              if result.get('action') == 'approved':
+                  asyncio.create_task(
+                      download_manager.execute_download(
+                          result['request_id'],
+                          'approved'
+                      )
+                  )
+
+          return jsonify({'ok': True})
+      ```
+
+   F. Add REST API endpoints:
+      ```python
+      # qBittorrent settings
+      @app.route('/api/qbittorrent/settings', methods=['GET', 'POST'])
+      @app.route('/api/qbittorrent/test-connection', methods=['POST'])
+
+      # Radarr settings
+      @app.route('/api/radarr/settings', methods=['GET', 'POST'])
+      @app.route('/api/radarr/test-connection', methods=['POST'])
+
+      # Download management
+      @app.route('/api/download/pending', methods=['GET'])
+      @app.route('/api/download/history', methods=['GET'])
+      @app.route('/api/download/approve', methods=['POST'])
+      @app.route('/api/download/decline', methods=['POST'])
+      @app.route('/api/download/active', methods=['GET'])  # From qBittorrent
+
+      # Notification settings
+      @app.route('/api/settings/notifications', methods=['GET', 'POST'])
+      ```
+
+2. CREATE DEDICATED SETTINGS PAGE
+
+   Need to create templates/settings.html with tabbed interface:
+
+   Tabs:
+   - 🔌 Connections (Plex, Telegram, IPT, Radarr, qBittorrent)
+   - 🔔 Notifications (Granular upgrade notification rules)
+   - 📥 Downloads (qBittorrent behavior, file naming)
+   - ⚙️ Advanced (Scanning, collections, reports)
+
+   Key features:
+   - Test buttons for each connection
+   - Live status indicators (✓ Connected / ✗ Error)
+   - Notification rule checkboxes with explanations
+   - Save button per tab
+   - Modern UI with Tailwind CSS
+
+   Files needed:
+   - templates/settings.html (~500 lines)
+   - static/css/settings.css (~200 lines) - if custom styles needed
+   - static/js/settings.js (~300 lines) - tab switching, API calls
+
+   Replace existing settings modal in templates/index.html
+
+3. UPDATE DASHBOARD (templates/index.html + static/js/newgui-app.js)
+
+   Add new section: "Pending Approvals"
+   ```html
+   <div class="pending-approvals">
+     <h3>Pending Download Approvals</h3>
+     <div v-if="pendingDownloads.length === 0">
+       No pending approvals
+     </div>
+     <div v-for="download in pendingDownloads" class="approval-card">
+       <h4>{{ download.movie_title }} ({{ download.year }})</h4>
+       <p>Current: {{ download.current_quality }}</p>
+       <p>New: {{ download.new_quality }}</p>
+       <p>Reason: {{ download.upgrade_reason }}</p>
+       <p>Expires: {{ formatExpiry(download.created_at) }}</p>
+       <button @click="approveDownload(download.request_id)">✅ Approve</button>
+       <button @click="declineDownload(download.request_id)">❌ Decline</button>
+     </div>
+   </div>
+   ```
+
+   Add new section: "Active Downloads"
+   ```html
+   <div class="active-downloads">
+     <h3>Active Downloads (qBittorrent)</h3>
+     <div v-for="torrent in activeDownloads" class="download-card">
+       <h4>{{ torrent.name }}</h4>
+       <div class="progress-bar">
+         <div class="progress" :style="{width: torrent.progress + '%'}"></div>
+       </div>
+       <p>{{ torrent.progress }}% | {{ formatSize(torrent.downloaded) }} / {{ formatSize(torrent.size) }}</p>
+       <p>⬇ {{ formatSpeed(torrent.dlspeed) }} | Seeds: {{ torrent.num_seeds }}</p>
+       <p>ETA: {{ formatETA(torrent.eta) }}</p>
+     </div>
+   </div>
+   ```
+
+   Update navigation to include settings page link:
+   ```html
+   <nav>
+     <a href="/">Dashboard</a>
+     <a href="/settings">⚙️ Settings</a>
+     <a href="/reports">Reports</a>
+   </nav>
+   ```
+
+   Remove settings modal code
+
+4. UPDATE SETTINGS.JSON SCHEMA
+
+   Add new configuration fields:
+   ```json
+   {
+     "// Existing settings": "...",
+
+     "// qBittorrent settings": "",
+     "qbittorrent_host": "10.0.0.63",
+     "qbittorrent_port": 8080,
+     "qbittorrent_username": "",
+     "qbittorrent_password": "",
+     "qbittorrent_category": "movies-fel",
+     "qbit_pause_on_add": false,
+     "qbit_sequential_download": true,
+     "qbit_upload_limit": 0,
+
+     "// Radarr settings": "",
+     "radarr_url": "http://10.0.0.63:7878",
+     "radarr_api_key": "",
+     "radarr_root_path": "/mnt/user/Media/Movies/",
+
+     "// Notification rules": "",
+     "notify_fel": true,
+     "notify_fel_from_p5": true,
+     "notify_fel_from_hdr": true,
+     "notify_fel_duplicates": false,
+     "notify_dv": false,
+     "notify_dv_from_hdr": true,
+     "notify_dv_profile_upgrades": true,
+     "notify_atmos": false,
+     "notify_atmos_only_if_no_atmos": true,
+     "notify_atmos_with_dv_upgrade": true,
+     "notify_resolution": false,
+     "notify_resolution_only_upgrades": true,
+     "notify_only_library_movies": true,
+     "notify_never_duplicates": true,
+     "notify_expire_hours": 24,
+
+     "// Download notifications": "",
+     "notify_download_start": true,
+     "notify_download_complete": true,
+     "notify_download_error": true,
+
+     "// Download behavior": "",
+     "download_keep_original_name": true,
+     "download_verify_disk_space": true,
+     "download_min_free_space_gb": 100,
+     "download_max_pending_approvals": 10
+   }
+   ```
+
+5. UPDATE README.md
+
+   Add new section: "Radarr + qBittorrent Integration"
+
+   Document:
+   - What it does (parallel version collection with approval)
+   - How to set up qBittorrent (enable WebUI, note the URL)
+   - How to set up Radarr (get API key, verify root folder path)
+   - How to configure Telegram webhook (for button callbacks)
+   - How notification filtering works
+   - How Plex version stacking works
+   - Example workflow with screenshots/diagrams
+
+   Add troubleshooting section:
+   - Telegram buttons not working → Check webhook
+   - Downloads not starting → Check qBit connection
+   - Folder not found → Check Radarr root path matches
+   - Too many notifications → Adjust notification rules
+
+================================================================================
+WHAT NEEDS TO BE TESTED (🧪)
+================================================================================
+
+1. QBITTORRENT CLIENT TESTING
+   [ ] Connection test to 10.0.0.63:8080
+   [ ] Add test torrent with specific save path
+   [ ] Verify torrent appears in qBittorrent
+   [ ] Check save path is correct
+   [ ] Get torrent list
+   [ ] Get torrent info by hash
+   [ ] Test with/without authentication
+
+2. RADARR CLIENT TESTING
+   [ ] Connection test
+   [ ] Get all movies list
+   [ ] Search for specific movie by title/year
+   [ ] Verify folder path matches expected format
+   [ ] Get movie file info (quality details)
+   [ ] Test with movie not in Radarr
+   [ ] Get quality profiles list
+   [ ] Get root folders list
+
+3. UPGRADE DETECTOR TESTING
+
+   Test cases for is_notification_worthy():
+   [ ] Already have P7 FEL → New P7 FEL = Skip (most important!)
+   [ ] Have P5 → New P7 FEL = Notify
+   [ ] Have HDR10 → New P7 FEL = Notify
+   [ ] Have HDR10 → New DV P5 = Check settings
+   [ ] Have P5 → New P8 = Check settings
+   [ ] Have no Atmos → New Atmos = Check settings
+   [ ] Have Atmos + P5 → New Atmos + P7 = Notify (combo)
+   [ ] Have 1080p → New 2160p = Check settings
+
+   Test torrent title parsing:
+   [ ] "Dune 2021 2160p DV FEL BL+EL+RPU" → Extracts all correctly
+   [ ] "Top.Gun.Maverick.2022.2160p.DV.Profile.7.FEL.Atmos"
+   [ ] "The Batman 2022 4K DV P7 FEL TrueHD Atmos"
+   [ ] Edge cases with weird formatting
+
+4. TELEGRAM HANDLER TESTING
+   [ ] Send test approval request
+   [ ] Verify message format (HTML rendering)
+   [ ] Verify buttons appear (✅ Download, ❌ Skip)
+   [ ] Test button press → Callback received
+   [ ] Verify message updates after button press
+   [ ] Test callback query answer (loading animation stops)
+   [ ] Test send_notification()
+   [ ] Test send_download_started()
+   [ ] Test send_download_completed()
+   [ ] Test send_download_error()
+   [ ] Test cleanup_expired() with old requests
+   [ ] Test connection test
+
+5. DOWNLOAD MANAGER TESTING
+
+   Full workflow test:
+   [ ] Create mock IPT discovery with FEL torrent
+   [ ] Verify movie lookup in database works
+   [ ] Verify current quality extraction works
+   [ ] Verify upgrade detector is called
+   [ ] Verify Radarr folder lookup works
+   [ ] Verify download request stored in database
+   [ ] Verify Telegram message sent
+   [ ] Simulate button press
+   [ ] Verify download execution starts
+   [ ] Verify qBittorrent receives torrent
+   [ ] Verify database updated correctly
+   [ ] Verify Telegram confirmations sent
+
+   Edge cases:
+   [ ] Movie not in Plex → Should skip
+   [ ] Movie not in Radarr → Should error
+   [ ] Already have same quality → Should skip
+   [ ] Invalid torrent title → Should error
+   [ ] qBittorrent unreachable → Should error
+   [ ] Telegram fails → Should log error but continue
+
+6. DATABASE TESTING
+   [ ] Store pending download
+   [ ] Retrieve pending download by request_id
+   [ ] Get all pending downloads
+   [ ] Mark download as started
+   [ ] Mark download as completed
+   [ ] Delete pending download
+   [ ] Get download history
+   [ ] Verify indices are created
+   [ ] Test with large number of records
+
+7. END-TO-END INTEGRATION TESTING
+
+   Scenario 1: Happy path (FEL upgrade)
+   [ ] IPT finds "Movie 2021 2160p DV FEL BL+EL+RPU"
+   [ ] User has Movie with DV Profile 5
+   [ ] System sends Telegram approval
+   [ ] User clicks ✅ Download
+   [ ] Torrent added to qBittorrent
+   [ ] Downloads to correct Radarr folder
+   [ ] Plex scans and stacks both versions
+   [ ] Radarr sees both files
+
+   Scenario 2: Duplicate skip
+   [ ] IPT finds "Movie 2021 2160p DV FEL BL+EL+RPU"
+   [ ] User already has Movie with DV Profile 7 FEL
+   [ ] System skips silently (no notification)
+
+   Scenario 3: User declines
+   [ ] IPT finds upgrade-worthy release
+   [ ] Telegram sent
+   [ ] User clicks ❌ Skip
+   [ ] Request removed from database
+   [ ] No download occurs
+
+   Scenario 4: Expired request
+   [ ] Telegram sent but no response for 24h
+   [ ] Request auto-expires
+   [ ] Cleanup job removes from database
+
+8. SETTINGS PAGE TESTING
+   [ ] Load existing settings
+   [ ] Modify each setting
+   [ ] Save each tab independently
+   [ ] Test connection buttons work
+   [ ] Verify settings persist to settings.json
+   [ ] Verify settings reload correctly
+   [ ] Test validation (e.g., invalid URLs)
+
+9. DASHBOARD UPDATES TESTING
+   [ ] Pending approvals section displays correctly
+   [ ] Approve button works from dashboard
+   [ ] Decline button works from dashboard
+   [ ] Active downloads section shows qBittorrent torrents
+   [ ] Progress bars update in real-time
+   [ ] Navigation to settings page works
+   [ ] Settings modal removed completely
+
+================================================================================
+CONFIGURATION REQUIREMENTS
+================================================================================
+
+Before testing, need to configure:
+
+1. In settings.json or environment variables:
+   - QBITTORRENT_HOST=10.0.0.63
+   - QBITTORRENT_PORT=8080
+   - RADARR_URL=http://10.0.0.63:7878
+   - RADARR_API_KEY=(get from Radarr settings → General → API Key)
+   - RADARR_ROOT_PATH=/mnt/user/Media/Movies/
+   - All notification rule preferences
+
+2. In Telegram:
+   - Set webhook URL to https://your-domain.com/telegram/webhook
+   - Or use long polling (check Telegram docs)
+
+3. In qBittorrent:
+   - Enable WebUI (Tools → Options → Web UI)
+   - Note the port (default 8080)
+   - If using auth, create username/password
+
+4. In Radarr:
+   - Get API key from Settings → General
+   - Verify root folder path matches what qBittorrent will use
+   - Ensure movies are already added to Radarr
+
+================================================================================
+KNOWN LIMITATIONS & CONSIDERATIONS
+================================================================================
+
+1. TELEGRAM WEBHOOK vs. LONG POLLING
+   - Current implementation assumes webhook
+   - For testing, can use ngrok or similar to expose local server
+   - Production should use proper HTTPS webhook
+   - Alternative: Implement long polling (more complex)
+
+2. ASYNC EXECUTION
+   - download_manager.execute_download() is async
+   - Need to ensure it runs in proper event loop context
+   - May need asyncio.create_task() or similar when called from Flask routes
+
+3. ERROR HANDLING
+   - Network timeouts (qBittorrent, Radarr, Telegram)
+   - Invalid API responses
+   - Database locks
+   - All have basic error handling but may need enhancement
+
+4. DUPLICATE DETECTION
+   - Currently relies on exact quality match
+   - Different release groups of same quality will be detected as duplicates
+   - User can override with notify_fel_duplicates setting
+
+5. TORRENT TITLE PARSING
+   - Regex patterns may not catch all formats
+   - May need to add more patterns based on actual IPT torrent titles
+   - Consider adding manual quality override option
+
+6. PLEX VERSION STACKING
+   - Plex must be configured to stack versions
+   - File naming should follow Plex guidelines
+   - May need to document recommended naming in README
+
+7. RADARR PATH MATCHING
+   - Assumes /mnt/user/Media/Movies/ is consistent
+   - If user has multiple root folders, may need to handle that
+   - Path should be exact match between Radarr and qBittorrent
+
+================================================================================
+DEPLOYMENT CHECKLIST
+================================================================================
+
+Before going live:
+[ ] Test all components individually
+[ ] Test full workflow end-to-end
+[ ] Configure Telegram webhook properly
+[ ] Set all notification preferences
+[ ] Test with real IPT torrents
+[ ] Verify qBittorrent downloads to correct folders
+[ ] Verify Plex detects and stacks versions
+[ ] Set up monitoring/logging
+[ ] Document configuration in README
+[ ] Create backup of database before enabling
+[ ] Test error scenarios (service down, etc.)
+[ ] Test Telegram button press from phone
+[ ] Verify message formatting on mobile
+[ ] Test with multiple pending approvals
+[ ] Test expiry cleanup job
+[ ] Load test with many torrents
+
+================================================================================
+FUTURE ENHANCEMENTS (Post-MVP)
+================================================================================
+
+Possible future additions:
+- Web dashboard for pending approvals (alternative to Telegram)
+- Auto-download rules (e.g., always download FEL for specific directors)
+- Quality priority system (prefer certain release groups)
+- Bandwidth scheduling (pause torrents during certain hours)
+- Download speed limits per category
+- Notification digest mode (batch notifications)
+- Integration with Plex to trigger library scans
+- Download completion webhook to notify when Plex should scan
+- Statistics dashboard (downloads per month, storage saved, etc.)
+- Multiple Telegram users (approval voting)
+- Discord/Slack integration alternative to Telegram
+- Mobile app for approvals
+- Browser extension for quick approvals
+
+================================================================================
+FILES CREATED/MODIFIED SUMMARY
+================================================================================
+
+NEW FILES CREATED:
+1. integrations/__init__.py (50 lines)
+2. integrations/qbittorrent.py (250 lines)
+3. integrations/radarr.py (220 lines)
+4. integrations/upgrade_detector.py (280 lines)
+5. integrations/telegram_handler.py (340 lines)
+6. integrations/download_manager.py (420 lines)
+
+MODIFIED FILES:
+1. scanner.py (+140 lines)
+   - Added pending_downloads table
+   - Added download_history table
+   - Added download management methods
+
+PENDING FILES TO CREATE:
+1. templates/settings.html (500 lines estimated)
+2. static/css/settings.css (200 lines estimated)
+3. static/js/settings.js (300 lines estimated)
+
+PENDING FILES TO MODIFY:
+1. app.py (large modifications needed)
+   - Import integration modules
+   - Initialize clients
+   - Add REST API endpoints
+   - Add Telegram webhook
+   - Hook into IPT scanner
+   - Add connection monitoring
+2. templates/index.html (moderate modifications)
+   - Add pending approvals section
+   - Add active downloads section
+   - Remove settings modal
+   - Add navigation link
+3. static/js/newgui-app.js (moderate modifications)
+   - Add pendingDownloads reactive state
+   - Add activeDownloads reactive state
+   - Add API calls for approvals
+   - Add qBittorrent status polling
+4. settings.json (configuration additions)
+   - Add all new configuration fields
+5. README.md (major additions)
+   - Document new integration
+   - Add setup instructions
+   - Add troubleshooting section
+
+ESTIMATED REMAINING WORK:
+- app.py integration: ~500-600 lines
+- Settings page creation: ~1000 lines (HTML/CSS/JS)
+- Dashboard updates: ~200 lines
+- Configuration & testing: Several hours
+- Documentation: ~200 lines in README
+
+TOTAL PROJECT SIZE (when complete): ~3,800 lines of new code
+
+================================================================================
+CONTACT POINTS IN EXISTING CODE
+================================================================================
+
+Where to hook into existing FELScanner code:
+
+1. IPT Scanner Callback
+   Location: Look for where iptscanner/monitor-iptorrents.js or
+            iptradar/fetch-once.js returns results
+   Current: Likely writes to iptscanner/data/latest_results.json
+   Action: Add download_manager.process_ipt_discovery() call after
+           new torrents detected
+
+2. Scanner Database Access
+   Location: state.scanner_obj.db (MovieDatabase instance)
+   Current: Already used for movie metadata
+   Action: Pass to download_manager for pending downloads tracking
+
+3. Telegram Configuration
+   Location: app.config['TELEGRAM_TOKEN'], app.config['TELEGRAM_CHAT_ID']
+   Current: Used for scan notifications
+   Action: Reuse same bot for download approvals
+
+4. Settings Loading
+   Location: load_settings() function in app.py
+   Current: Loads from settings.json
+   Action: Add new configuration fields
+
+5. Connection Status Tracking
+   Location: state.connection_status dict
+   Current: Tracks Plex, Telegram, IPTorrents
+   Action: Add 'radarr' and 'qbittorrent' entries
+
+6. REST API Patterns
+   Location: Various @app.route() endpoints
+   Current: /api/status, /api/metrics, /api/connections, etc.
+   Action: Follow same patterns for new endpoints
+
+================================================================================
+PRIORITY ORDER FOR REMAINING WORK
+================================================================================
+
+1. HIGH PRIORITY (Must have for basic functionality):
+   [ ] Wire download manager into app.py
+   [ ] Add Telegram webhook endpoint
+   [ ] Hook into IPT scanner callback
+   [ ] Test basic workflow with manual trigger
+   [ ] Add qBittorrent/Radarr settings to settings.json
+
+2. MEDIUM PRIORITY (Important for usability):
+   [ ] Create settings page with notification rules
+   [ ] Add pending approvals section to dashboard
+   [ ] Add connection monitoring
+   [ ] Test with real IPT torrents
+
+3. LOW PRIORITY (Nice to have):
+   [ ] Add active downloads section to dashboard
+   [ ] Add download history endpoint
+   [ ] Clean up settings modal code completely
+   [ ] Add comprehensive README documentation
+
+================================================================================
+DEBUGGING TIPS
+================================================================================
+
+When things go wrong, check:
+
+1. Telegram not sending messages:
+   - Check bot token is correct
+   - Check chat ID is correct
+   - Check network connectivity
+   - Look for Telegram API errors in logs
+   - Test with telegram_handler.test_connection()
+
+2. Notifications for wrong movies:
+   - Check upgrade_detector configuration
+   - Add debug logging to is_notification_worthy()
+   - Verify database has correct current quality
+   - Check torrent title parsing
+
+3. qBittorrent not receiving torrents:
+   - Check qBittorrent WebUI is accessible
+   - Check host/port configuration
+   - Check authentication (if enabled)
+   - Try manual qbt_client.add_torrent() call
+   - Check qBittorrent logs
+
+4. Wrong folder path:
+   - Verify Radarr root path matches qBittorrent save path
+   - Check radarr_client.get_movie_folder() output
+   - Verify movie exists in Radarr
+   - Check Radarr API response
+
+5. Database errors:
+   - Check table schema was created
+   - Look for SQLite lock errors
+   - Verify JSON serialization/deserialization
+   - Check database file permissions
+
+6. Telegram buttons not working:
+   - Verify webhook is set up
+   - Check callback data format
+   - Look for callback_query in webhook logs
+   - Test with manual Telegram API call
+
+LOG LOCATIONS:
+- Flask logs: Console output or flask.log
+- qBittorrent logs: qBittorrent → Tools → Log
+- Radarr logs: Radarr → System → Logs
+- Telegram: Check bot messages in chat
+- Database: Add logging to MovieDatabase methods
+
+================================================================================
+END OF DOCUMENTATION
+================================================================================

--- a/static/js/newgui-app.js
+++ b/static/js/newgui-app.js
@@ -23,6 +23,24 @@ const postForm = async (url, data = {}) => {
     return response.text();
 };
 
+const fetchMovieAPI = async (url) => {
+    const response = await fetch(url, { credentials: 'same-origin' });
+    const text = await response.text();
+    let payload = {};
+    if (text) {
+        try {
+            payload = JSON.parse(text);
+        } catch (error) {
+            throw new Error(`Invalid JSON response from ${url}`);
+        }
+    }
+    if (!response.ok) {
+        const message = payload && payload.error ? payload.error : `Request failed: ${response.status}`;
+        throw new Error(message);
+    }
+    return payload;
+};
+
 createApp({
     setup() {
         const loading = ref(true);
@@ -41,7 +59,7 @@ createApp({
             ratios: { dv_percent: 0, atmos_percent: 0, fel_percent: 0, dv_and_atmos: 0, fel_and_atmos: 0 },
             dv_profiles: [],
             year_breakdown: [],
-            quality: { avg_file_size_gb: 0, avg_bitrate_mbps: 0 },
+            quality: { median_file_size_gb: 0, median_bitrate_mbps: 0 },
             recent: []
         });
         const reports = ref([]);
@@ -78,6 +96,134 @@ createApp({
             telegram: { testing: false, success: false, message: '' },
             flaresolverr: { testing: false, success: false, message: '' },
             ipt: { testing: false, success: false, message: '' }
+        });
+        const metadata = reactive({
+            movies: [],
+            summaryRefreshedAt: null
+        });
+        const movieSearch = ref('');
+        const metadataLoading = reactive({ list: false, detail: false });
+        const metadataError = reactive({ list: '', detail: '' });
+        const metadataFilters = reactive({
+            dvMode: 'off', // off, any, p7fel, other
+            atmosOnly: false,
+            resolution: 'all',
+            sort: 'title'
+        });
+        const selectedMovie = ref(null);
+        const selectedVersionId = ref(null);
+        const getVersionFeatures = (version) => (version && version.features) ? version.features : {};
+
+        const resolutionRank = (version) => {
+            const features = getVersionFeatures(version);
+            if (features.resolutionRank) return features.resolutionRank;
+            const res = (version?.videoResolution || '').toString().toLowerCase();
+            if (['4k', '2160', '2160p', 'uhd'].some((item) => res.includes(item))) return 3;
+            if (['1080', '1080p'].some((item) => res.includes(item))) return 2;
+            if (['720', '720p'].some((item) => res.includes(item))) return 1;
+            const height = Number(version?.height);
+            if (Number.isFinite(height)) {
+                if (height >= 1700) return 3;
+                if (height >= 900) return 2;
+                if (height >= 700) return 1;
+            }
+            return 0;
+        };
+
+        const versionScore = (version) => {
+            if (!version) return -1;
+            const features = getVersionFeatures(version);
+            let score = 0;
+            if (features.hasDolbyVision) score += 100;
+            if (features.dolbyVisionIsProfile7) score += 15;
+            if (features.dolbyVisionHasFEL) score += 10;
+            if (features.hasAtmos) score += 25;
+            score += resolutionRank(version) * 5;
+            if ((version.videoCodec || '').toLowerCase() === 'hevc') score += 2;
+            if ((version.audioCodec || '').toLowerCase().includes('truehd')) score += 1;
+            return score;
+        };
+
+        const getPreferredVersion = (movie) => {
+            if (!movie || !Array.isArray(movie.versions) || !movie.versions.length) return null;
+            if (movie.versions.length === 1) return movie.versions[0];
+            const sorted = [...movie.versions].sort((a, b) => versionScore(b) - versionScore(a));
+            return sorted[0];
+        };
+
+        const getPreferredVersionId = (movie) => {
+            const preferred = getPreferredVersion(movie);
+            if (preferred && preferred.id !== undefined && preferred.id !== null) {
+                return preferred.id;
+            }
+            if (movie && Array.isArray(movie.versions) && movie.versions.length) {
+                return movie.versions[0].id ?? null;
+            }
+            return null;
+        };
+
+        const filteredMovies = Vue.computed(() => {
+            const query = movieSearch.value.trim().toLowerCase();
+            const matchesQuery = (movie) => {
+                if (!query) return true;
+                const haystack = [
+                    movie.title || '',
+                    movie.year ? String(movie.year) : '',
+                    ...(movie.collections || [])
+                ].join(' ').toLowerCase();
+                return haystack.includes(query);
+            };
+
+            const matchesFilters = (movie) => {
+                const preferred = getPreferredVersion(movie);
+                const features = getVersionFeatures(preferred);
+                if (metadataFilters.dvMode === 'any' && !features.hasDolbyVision) return false;
+                if (metadataFilters.dvMode === 'p7fel' && !(features.hasDolbyVision && features.dolbyVisionIsProfile7 && features.dolbyVisionHasFEL)) return false;
+                if (metadataFilters.dvMode === 'other' && !(features.hasDolbyVision && (!features.dolbyVisionIsProfile7 || !features.dolbyVisionHasFEL))) return false;
+                if (metadataFilters.atmosOnly && !features.hasAtmos) return false;
+                if (metadataFilters.resolution !== 'all') {
+                    const rank = features.resolutionRank || resolutionRank(preferred);
+                    if (metadataFilters.resolution === '4k' && rank < 3) return false;
+                    if (metadataFilters.resolution === '1080p' && (rank < 2 || rank >= 3)) return false;
+                    if (metadataFilters.resolution === '720p' && rank !== 1) return false;
+                }
+                return true;
+            };
+
+            const sorter = (a, b) => {
+                const sortKey = metadataFilters.sort;
+                if (sortKey === 'dv') {
+                    return versionScore(getPreferredVersion(b)) - versionScore(getPreferredVersion(a));
+                }
+                if (sortKey === 'resolution') {
+                    return resolutionRank(getPreferredVersion(b)) - resolutionRank(getPreferredVersion(a));
+                }
+                if (sortKey === 'recent') {
+                    const atA = new Date(a.updatedAt || a.addedAt || 0).getTime();
+                    const atB = new Date(b.updatedAt || b.addedAt || 0).getTime();
+                    return atB - atA;
+                }
+                // default title sort
+                const titleA = (a.title || '').toLowerCase();
+                const titleB = (b.title || '').toLowerCase();
+                if (titleA < titleB) return -1;
+                if (titleA > titleB) return 1;
+                return 0;
+            };
+
+            return metadata.movies
+                .filter((movie) => matchesQuery(movie) && matchesFilters(movie))
+                .slice()
+                .sort(sorter);
+        });
+        const selectedVersion = Vue.computed(() => {
+            if (!selectedMovie.value || !Array.isArray(selectedMovie.value.versions)) return null;
+            const versions = selectedMovie.value.versions;
+            if (!versions.length) return null;
+            if (!selectedVersionId.value) {
+                return getPreferredVersion(selectedMovie.value) || versions[0];
+            }
+            return versions.find((item) => String(item.id) === String(selectedVersionId.value)) || versions[0];
         });
         let profileChart = null;
         let chartDark = true;
@@ -126,6 +272,167 @@ createApp({
             return date.toLocaleDateString();
         };
 
+        const formatFileSize = (value) => {
+            const bytes = Number(value);
+            if (!Number.isFinite(bytes) || bytes <= 0) return '—';
+            const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+            let size = bytes;
+            let unitIndex = 0;
+            while (size >= 1024 && unitIndex < units.length - 1) {
+                size /= 1024;
+                unitIndex += 1;
+            }
+            const precision = size >= 10 || unitIndex === 0 ? 0 : 1;
+            return `${size.toFixed(precision)} ${units[unitIndex]}`;
+        };
+
+        const formatBitrate = (value) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric) || numeric <= 0) return '—';
+            const kbps = numeric > 100000 ? numeric / 1000 : numeric;
+            if (kbps >= 1000) {
+                return `${(kbps / 1000).toFixed(1)} Mbps`;
+            }
+            return `${Math.round(kbps)} Kbps`;
+        };
+
+        const formatDuration = (value) => {
+            const ms = Number(value);
+            if (!Number.isFinite(ms) || ms <= 0) return '—';
+            const totalSeconds = Math.floor(ms / 1000);
+            const hours = Math.floor(totalSeconds / 3600);
+            const minutes = Math.floor((totalSeconds % 3600) / 60);
+            const seconds = totalSeconds % 60;
+            if (hours > 0) {
+                return `${hours}h ${minutes}m`;
+            }
+            if (minutes > 0) {
+                return `${minutes}m ${seconds}s`;
+            }
+            return `${seconds}s`;
+        };
+
+        const formatResolution = (version) => {
+            if (!version) return '—';
+            if (version.width && version.height) {
+                return `${version.width}×${version.height}`;
+            }
+            if (version.videoResolution) {
+                return String(version.videoResolution).toUpperCase();
+            }
+            return '—';
+        };
+
+        const formatAudioSummary = (version) => {
+            if (!version) return '—';
+            const codec = version.audioCodec ? String(version.audioCodec).toUpperCase() : null;
+            const channels = version.audioChannels ? `${version.audioChannels}ch` : null;
+            return [codec, channels].filter(Boolean).join(' · ') || '—';
+        };
+
+        const formatVersionLabel = (version) => {
+            if (!version) return 'Version';
+            return [
+                formatResolution(version),
+                version.videoCodec ? String(version.videoCodec).toUpperCase() : null,
+                version.container ? String(version.container).toUpperCase() : null
+            ].filter(Boolean).join(' · ') || 'Version';
+        };
+
+        const dvLabel = (features) => {
+            if (!features || !features.hasDolbyVision) return null;
+            if (features.dolbyVisionIsProfile7) {
+                return features.dolbyVisionHasFEL ? 'Dolby Vision P7 FEL' : 'Dolby Vision P7';
+            }
+            return 'Dolby Vision';
+        };
+
+        const formatVersionSummary = (version) => {
+            if (!version) return 'Version data unavailable';
+            const features = getVersionFeatures(version);
+            const summary = [];
+            const dv = dvLabel(features);
+            if (dv) summary.push(dv);
+            else if (features.dynamicRange) summary.push(features.dynamicRange);
+            summary.push(formatResolution(version));
+            if (version.videoCodec) summary.push(String(version.videoCodec).toUpperCase());
+            if (features.audioFormats && features.audioFormats.length) {
+                summary.push(features.audioFormats[0]);
+            } else {
+                summary.push(formatAudioSummary(version));
+            }
+            return summary.filter(Boolean).join(' · ') || 'Version data unavailable';
+        };
+
+        const formatLanguage = (code) => {
+            if (!code) return null;
+            return String(code).toUpperCase();
+        };
+
+        const formatSampleRate = (value) => {
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric) || numeric <= 0) return null;
+            if (numeric >= 1000) {
+                const khz = numeric / 1000;
+                return `${Number.isInteger(khz) ? khz.toFixed(0) : khz.toFixed(1)} kHz`;
+            }
+            return `${Math.round(numeric)} Hz`;
+        };
+
+        const formatChannels = (stream) => {
+            if (!stream) return null;
+            if (stream.channelLayout) {
+                return String(stream.channelLayout).toUpperCase();
+            }
+            if (stream.channels) {
+                return `${stream.channels}ch`;
+            }
+            return null;
+        };
+
+        const describeVideoStream = (stream) => {
+            if (!stream) return '';
+            const details = [
+                stream.codec ? String(stream.codec).toUpperCase() : null,
+                stream.width && stream.height ? `${stream.width}×${stream.height}` : null,
+                stream.profile || null,
+                stream.bitDepth ? `${stream.bitDepth}-bit` : null,
+                stream.colorTransfer || stream.colorPrimaries
+                    ? [stream.colorTransfer, stream.colorPrimaries].filter(Boolean).join('/')
+                    : null
+            ].filter(Boolean);
+            return details.join(' · ');
+        };
+
+        const describeAudioStream = (stream) => {
+            if (!stream) return '';
+            const bitRate = formatBitrate(stream.bitRate);
+            const sample = formatSampleRate(stream.sampleRate);
+            const details = [
+                stream.codec ? String(stream.codec).toUpperCase() : null,
+                formatChannels(stream),
+                sample,
+                bitRate !== '—' ? bitRate : null,
+                formatLanguage(stream.language),
+                stream.title || null
+            ].filter(Boolean);
+            return details.join(' · ');
+        };
+
+        const describeSubtitleStream = (stream) => {
+            if (!stream) return '';
+            const flags = [];
+            if (stream.forced) flags.push('Forced');
+            if (stream.hearingImpaired) flags.push('SDH');
+            const details = [
+                stream.codec ? String(stream.codec).toUpperCase() : null,
+                formatLanguage(stream.language),
+                stream.title || null,
+                flags.length ? flags.join(', ') : null
+            ].filter(Boolean);
+            return details.join(' · ');
+        };
+
         const refreshStatus = async () => {
             const payload = await fetchJSON('/api/status');
             state.is_scanning = payload.status?.is_scanning || false;
@@ -164,6 +471,168 @@ createApp({
             Object.assign(connections, payload);
         };
 
+        const refreshMetadataList = async (forceRefresh = false) => {
+            metadataLoading.list = true;
+            metadataError.list = '';
+            try {
+                const url = forceRefresh ? '/api/movies?refresh=1' : '/api/movies';
+                const payload = await fetchMovieAPI(url);
+                const previousMap = new Map(
+                    metadata.movies.map((item) => [String(item.ratingKey), item])
+                );
+                const items = (payload.movies || []).map((item) => {
+                    const key = String(item.ratingKey);
+                    const previous = previousMap.get(key);
+                    if (
+                        previous &&
+                        previous.detailRefreshedAt &&
+                        (!item.detailRefreshedAt || item.detailRefreshedAt === previous.detailRefreshedAt)
+                    ) {
+                        return { ...item, versions: previous.versions };
+                    }
+                    return item;
+                });
+                items.sort((a, b) => {
+                    const titleA = (a.title || '').toLowerCase();
+                    const titleB = (b.title || '').toLowerCase();
+                    if (titleA < titleB) return -1;
+                    if (titleA > titleB) return 1;
+                    return 0;
+                });
+                metadata.movies = items;
+                metadata.summaryRefreshedAt = payload.summaryRefreshedAt || null;
+
+                if (selectedMovie.value) {
+                    const match = items.find(
+                        (item) => String(item.ratingKey) === String(selectedMovie.value.ratingKey)
+                    );
+                    if (match) {
+                        selectedMovie.value = match;
+                    }
+                }
+            } catch (error) {
+                metadataError.list = error.message || 'Failed to load movie metadata.';
+                console.error('Failed to load metadata list', error);
+            } finally {
+                metadataLoading.list = false;
+            }
+        };
+
+        const loadMovieDetail = async (ratingKey, forceRefresh = true) => {
+            if (!ratingKey) return null;
+            metadataLoading.detail = true;
+            metadataError.detail = '';
+            const key = String(ratingKey);
+            const previousVersionId = selectedVersionId.value ? String(selectedVersionId.value) : null;
+            try {
+                const url = forceRefresh ? `/api/movies/${key}?refresh=1` : `/api/movies/${key}`;
+                const payload = await fetchMovieAPI(url);
+                if (!payload.movie) {
+                    throw new Error(payload.error || 'Metadata unavailable.');
+                }
+                const detail = payload.movie;
+                selectedMovie.value = detail;
+
+                const versionIds = (detail.versions || []).map((item) => String(item.id));
+                if (previousVersionId && versionIds.includes(previousVersionId)) {
+                    selectedVersionId.value = previousVersionId;
+                } else {
+                    selectedVersionId.value = getPreferredVersionId(detail);
+                }
+
+                const index = metadata.movies.findIndex(
+                    (item) => String(item.ratingKey) === String(detail.ratingKey)
+                );
+                if (index >= 0) {
+                    metadata.movies.splice(index, 1, detail);
+                } else {
+                    metadata.movies.push(detail);
+                    metadata.movies.sort((a, b) => (a.title || '').localeCompare(b.title || ''));
+                }
+
+                if (detail.detailError) {
+                    metadataError.detail = detail.detailError;
+                }
+                return detail;
+            } catch (error) {
+                metadataError.detail = error.message || 'Failed to load metadata.';
+                console.error('Failed to load movie detail', error);
+                return null;
+            } finally {
+                metadataLoading.detail = false;
+            }
+        };
+
+        const versionSummaryTags = (version) => {
+            const features = getVersionFeatures(version);
+            return features.summaryTags || [];
+        };
+
+        const tagBadgeClass = (tag) => {
+            const lower = (tag || '').toLowerCase();
+            if (lower.includes('fel')) return 'border-indigo-500/60 bg-indigo-500/10 text-indigo-200';
+            if (lower.includes('do vi') || lower.includes('dolby vision')) return 'border-indigo-500/40 bg-indigo-500/5 text-indigo-100';
+            if (lower.includes('atmos')) return 'border-teal-500/60 bg-teal-500/10 text-teal-200';
+            if (lower.includes('4k')) return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+            return 'border-slate-700 bg-slate-900/60 text-slate-300';
+        };
+
+        const selectMovie = async (movie, options = {}) => {
+            if (!movie || !movie.ratingKey) return;
+            selectedMovie.value = movie;
+            selectedVersionId.value = getPreferredVersionId(movie);
+            metadataError.detail = '';
+            const forceRefresh = options.refresh !== undefined ? options.refresh : true;
+            await loadMovieDetail(movie.ratingKey, forceRefresh);
+        };
+
+        const refreshSelectedMovie = async () => {
+            if (!selectedMovie.value || !selectedMovie.value.ratingKey) return;
+            metadataError.detail = '';
+            await loadMovieDetail(selectedMovie.value.ratingKey, true);
+        };
+
+        const setSelectedVersion = (versionId) => {
+            selectedVersionId.value = versionId;
+        };
+
+        const cycleDvFilter = () => {
+            const order = ['off', 'any', 'p7fel', 'other'];
+            const idx = order.indexOf(metadataFilters.dvMode);
+            metadataFilters.dvMode = order[(idx + 1) % order.length];
+        };
+
+        const dvFilterLabel = Vue.computed(() => {
+            switch (metadataFilters.dvMode) {
+                case 'any':
+                    return 'DV: Any';
+                case 'p7fel':
+                    return 'DV: P7 FEL';
+                case 'other':
+                    return 'DV: Other';
+                default:
+                    return 'DV: Off';
+            }
+        });
+
+        const dvFilterActive = Vue.computed(() => metadataFilters.dvMode !== 'off');
+
+        const movieByRatingKey = (ratingKey) => {
+            if (!ratingKey) return null;
+            return metadata.movies.find((item) => String(item.ratingKey) === String(ratingKey)) || null;
+        };
+
+        const openRecentMovie = async (item) => {
+            if (!item || !item.rating_key) return;
+            const ratingKey = String(item.rating_key);
+            const existing = movieByRatingKey(ratingKey);
+            if (existing) {
+                await selectMovie(existing, { refresh: true });
+                return;
+            }
+            await loadMovieDetail(ratingKey, true);
+        };
+
         const refreshAll = async () => {
             loading.value = true;
             await Promise.all([
@@ -171,7 +640,8 @@ createApp({
                 refreshMetrics(),
                 refreshReports(),
                 refreshIPT(),
-                refreshConnections()
+                refreshConnections(),
+                refreshMetadataList()
             ]).catch((error) => console.error('Refresh error', error));
             loading.value = false;
         };
@@ -447,10 +917,42 @@ createApp({
             testStatus,
             refreshAll,
             refreshIPT,
+            metadata,
+            movieSearch,
+            metadataFilters,
+            filteredMovies,
+            metadataLoading,
+            metadataError,
+            selectedMovie,
+            selectedVersion,
+            selectedVersionId,
+            refreshMetadataList,
+            getPreferredVersion,
+            getVersionFeatures,
+            versionSummaryTags,
+            tagBadgeClass,
+            selectMovie,
+            refreshSelectedMovie,
+            setSelectedVersion,
+            cycleDvFilter,
+            dvFilterLabel,
+            dvFilterActive,
+            movieByRatingKey,
+            openRecentMovie,
             triggerAction,
             toggleChartTheme,
             formatTimestamp,
             formatRelative,
+            formatFileSize,
+            formatBitrate,
+            formatDuration,
+            formatResolution,
+            formatAudioSummary,
+            formatVersionSummary,
+            formatVersionLabel,
+            describeVideoStream,
+            describeAudioStream,
+            describeSubtitleStream,
             saveSettings,
             testPlex,
             testTelegram,

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,22 +82,297 @@
                     </div>
                 </section>
 
+                <section class="rounded-3xl border border-slate-800 bg-slateglass p-6 backdrop-blur-xl">
+                    <div class="flex flex-wrap items-center justify-between gap-4">
+                        <div>
+                            <h3 class="text-xl font-semibold text-white">Metadata Explorer</h3>
+                            <p class="text-sm text-slate-400">Browse cached Plex metadata and pull live ffprobe details when you open a movie.</p>
+                        </div>
+                        <div class="flex items-center gap-3 text-xs text-slate-400">
+                            <span v-if="metadata.summaryRefreshedAt">Cache {{ formatRelative(metadata.summaryRefreshedAt) }}</span>
+                            <button @click="refreshMetadataList(true)" :disabled="metadataLoading.list" class="rounded-md border border-slate-700 px-3 py-1.5 font-medium text-slate-200 hover:bg-slate-900/70 disabled:cursor-not-allowed disabled:opacity-40">Refresh cache</button>
+                        </div>
+                    </div>
+                    <div class="mt-6 grid gap-6 xl:grid-cols-5">
+                        <div class="xl:col-span-2 space-y-4">
+                            <div class="relative">
+                                <input v-model="movieSearch" type="search" placeholder="Search movies…" class="w-full rounded-xl border border-slate-800 bg-slate-900/70 pl-10 pr-4 py-2.5 text-sm text-slate-200 placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/30">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-4.35-4.35M9.5 17A7.5 7.5 0 109.5 2a7.5 7.5 0 000 15z" />
+                                </svg>
+                            </div>
+                            <div class="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-wide text-slate-400">
+                                <button @click="cycleDvFilter" :class="dvFilterActive ? 'border-indigo-500/60 bg-indigo-500/10 text-indigo-200' : 'border-slate-700 text-slate-400 hover:bg-slate-900'" class="rounded-md border px-3 py-1 font-semibold transition">{{ dvFilterLabel }}</button>
+                                <button @click="metadataFilters.atmosOnly = !metadataFilters.atmosOnly" :class="metadataFilters.atmosOnly ? 'bg-teal-500/20 text-teal-200 border-teal-500/50' : 'border-slate-700 text-slate-400 hover:bg-slate-900'" class="rounded-md border px-3 py-1 font-semibold transition">Atmos</button>
+                                <div class="flex items-center gap-1">
+                                    <span class="text-slate-500">Resolution</span>
+                                    <button @click="metadataFilters.resolution = 'all'" :class="metadataFilters.resolution === 'all' ? 'bg-slate-100/10 text-slate-200 border-slate-100/40' : 'border-slate-700 text-slate-400 hover:bg-slate-900'" class="rounded-md border px-2 py-1 font-semibold transition">All</button>
+                                    <button @click="metadataFilters.resolution = '4k'" :class="metadataFilters.resolution === '4k' ? 'bg-slate-100/10 text-slate-200 border-slate-100/40' : 'border-slate-700 text-slate-400 hover:bg-slate-900'" class="rounded-md border px-2 py-1 font-semibold transition">4K</button>
+                                    <button @click="metadataFilters.resolution = '1080p'" :class="metadataFilters.resolution === '1080p' ? 'bg-slate-100/10 text-slate-200 border-slate-100/40' : 'border-slate-700 text-slate-400 hover:bg-slate-900'" class="rounded-md border px-2 py-1 font-semibold transition">1080p</button>
+                                </div>
+                                <label class="ml-auto flex items-center gap-2 text-slate-500">
+                                    <span>Sort</span>
+                                    <select v-model="metadataFilters.sort" class="rounded-md border border-slate-800 bg-slate-900/70 px-2 py-1 text-[11px] text-slate-300 focus:border-indigo-500 focus:outline-none">
+                                        <option value="title">Title</option>
+                                        <option value="dv">Dolby Vision first</option>
+                                        <option value="resolution">Resolution</option>
+                                        <option value="recent">Recently updated</option>
+                                    </select>
+                                </label>
+                            </div>
+                            <div class="max-h-[28rem] space-y-2 overflow-y-auto pr-1">
+                                <div v-if="metadataLoading.list" class="rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-6 text-center text-sm text-slate-400">
+                                    Loading metadata…
+                                </div>
+                                <template v-else>
+                                    <button
+                                        v-for="movie in filteredMovies"
+                                        :key="movie.ratingKey"
+                                        @click="selectMovie(movie)"
+                                        class="w-full rounded-2xl border px-4 py-3 text-left transition"
+                                        :class="selectedMovie && String(selectedMovie.ratingKey) === String(movie.ratingKey)
+                                            ? 'border-indigo-500 bg-indigo-500/10 text-indigo-100'
+                                            : 'border-slate-800 bg-slate-900/60 text-slate-200 hover:border-slate-700 hover:bg-slate-900/80'"
+                                    >
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div>
+                                                <p class="text-sm font-semibold text-white">
+                                                    {{ movie.title }}
+                                                    <span v-if="movie.year" class="ml-1 text-xs font-normal text-slate-400">({{ movie.year }})</span>
+                                                </p>
+                                                <p class="mt-1 text-xs text-slate-400">{{ formatVersionSummary(getPreferredVersion(movie)) }}</p>
+                                                <p v-if="movie.collections && movie.collections.length" class="mt-1 text-[11px] uppercase tracking-wide text-slate-500">
+                                                    {{ movie.collections.join(' · ') }}
+                                                </p>
+                                                <div v-if="versionSummaryTags(getPreferredVersion(movie)).length" class="mt-2 flex flex-wrap gap-2 text-[10px] font-medium uppercase tracking-wide">
+                                                    <span v-for="tag in versionSummaryTags(getPreferredVersion(movie))" :key="tag" class="rounded-full border px-2 py-0.5" :class="tagBadgeClass(tag)">
+                                                        {{ tag }}
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            <div class="text-right text-[11px] text-slate-500 leading-relaxed">
+                                                <p v-if="movie.detailRefreshedAt">Live {{ formatRelative(movie.detailRefreshedAt) }}</p>
+                                                <p v-else-if="movie.summaryRefreshedAt">Cached {{ formatRelative(movie.summaryRefreshedAt) }}</p>
+                                                <p v-else>Cache pending</p>
+                                                <p class="mt-1 text-slate-400">{{ movie.versions?.length || 0 }} versions</p>
+                                            </div>
+                                        </div>
+                                    </button>
+                                    <p v-if="!filteredMovies.length" class="rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-6 text-center text-sm text-slate-500">
+                                        No movies match "{{ movieSearch }}".
+                                    </p>
+                                    <p v-if="metadataError.list && !metadata.movies.length" class="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-6 text-center text-xs text-rose-200">
+                                        {{ metadataError.list }}
+                                    </p>
+                                </template>
+                            </div>
+                        </div>
+                        <div class="xl:col-span-3">
+                            <div class="min-h-[28rem] rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+                                <template v-if="!selectedMovie">
+                                    <div class="flex h-full items-center justify-center text-sm text-slate-500">
+                                        Select a movie from the left to view its metadata.
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    <div class="flex flex-wrap items-start justify-between gap-4">
+                                        <div class="space-y-2">
+                                            <div class="flex items-center gap-2">
+                                                <h4 class="text-2xl font-semibold text-white">{{ selectedMovie.title }}</h4>
+                                                <span v-if="selectedMovie.year" class="text-base font-medium text-slate-400">({{ selectedMovie.year }})</span>
+                                            </div>
+                                            <p v-if="selectedMovie.tagline" class="text-sm text-slate-400">{{ selectedMovie.tagline }}</p>
+                                            <p class="text-xs text-slate-500">
+                                                Last live pull:
+                                                <span v-if="selectedMovie.detailRefreshedAt">{{ formatRelative(selectedMovie.detailRefreshedAt) }}</span>
+                                                <span v-else>Not yet generated</span>
+                                            </p>
+                                        </div>
+                                        <div class="flex items-center gap-2">
+                                            <button
+                                                @click="refreshSelectedMovie"
+                                                :disabled="!selectedMovie || metadataLoading.detail"
+                                                class="rounded-md border border-indigo-500/50 px-3 py-1.5 text-xs font-medium text-indigo-200 hover:bg-indigo-500/10 disabled:cursor-not-allowed disabled:opacity-40"
+                                            >
+                                                Pull live EXIF
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <p v-if="metadataLoading.detail" class="mt-4 rounded-xl border border-slate-800 bg-slate-900/60 px-4 py-3 text-sm text-slate-300">
+                                        Running ffprobe… this can take a few seconds.
+                                    </p>
+                                    <p v-if="metadataError.detail" class="mt-4 rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-xs text-rose-200">
+                                        {{ metadataError.detail }}
+                                    </p>
+                                    <div class="mt-6 space-y-4" v-if="selectedMovie.versions && selectedMovie.versions.length">
+                                        <div class="flex flex-wrap items-center gap-2">
+                                            <button
+                                                v-for="version in selectedMovie.versions"
+                                                :key="version.id"
+                                                class="rounded-md border px-3 py-1 text-xs font-medium transition"
+                                                :class="String(selectedVersionId) === String(version.id)
+                                                    ? 'border-indigo-400 bg-indigo-500/10 text-indigo-200'
+                                                    : 'border-slate-700 bg-slate-900/60 text-slate-300 hover:border-slate-600 hover:bg-slate-900'"
+                                                @click="setSelectedVersion(version.id)"
+                                            >
+                                                {{ formatVersionLabel(version) }}
+                                            </button>
+                                        </div>
+                                        <div v-if="selectedVersion" class="space-y-4">
+                                            <div class="grid gap-4 md:grid-cols-5">
+                                                <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                                                    <p class="text-xs uppercase tracking-wide text-slate-400">Resolution</p>
+                                                    <p class="mt-1 text-sm font-medium text-white">{{ formatResolution(selectedVersion) }}</p>
+                                                </div>
+                                                <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                                                    <p class="text-xs uppercase tracking-wide text-slate-400">Dynamic Range</p>
+                                                    <p class="mt-1 text-sm font-medium text-white">
+                                                        <template v-if="getVersionFeatures(selectedVersion).hasDolbyVision">
+                                                            DoVi {{ getVersionFeatures(selectedVersion).dolbyVisionLabel || 'Present' }}
+                                                        </template>
+                                                        <template v-else>
+                                                            {{ getVersionFeatures(selectedVersion).dynamicRange || '—' }}
+                                                        </template>
+                                                    </p>
+                                                    <p class="text-xs text-slate-500" v-if="getVersionFeatures(selectedVersion).colorPrimaries">
+                                                        {{ getVersionFeatures(selectedVersion).colorPrimaries }} · {{ getVersionFeatures(selectedVersion).colorTrc || 'PQ' }}
+                                                    </p>
+                                                </div>
+                                                <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                                                    <p class="text-xs uppercase tracking-wide text-slate-400">Video</p>
+                                                    <p class="mt-1 text-sm font-medium text-white">
+                                                        {{ selectedVersion.videoCodec ? selectedVersion.videoCodec.toUpperCase() : '—' }}
+                                                    </p>
+                                                    <p class="text-xs text-slate-500">
+                                                        {{ formatBitrate(selectedVersion.bitrate) }} · {{ formatDuration(selectedVersion.duration) }}
+                                                    </p>
+                                                </div>
+                                                <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                                                    <p class="text-xs uppercase tracking-wide text-slate-400">Audio</p>
+                                                    <p class="mt-1 text-sm font-medium text-white">{{ formatAudioSummary(selectedVersion) }}</p>
+                                                    <p class="text-xs text-slate-500" v-if="getVersionFeatures(selectedVersion).hasAtmos">Dolby Atmos detected</p>
+                                                </div>
+                                                <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                                                    <p class="text-xs uppercase tracking-wide text-slate-400">Container</p>
+                                                    <p class="mt-1 text-sm font-medium text-white">{{ selectedVersion.container ? selectedVersion.container.toUpperCase() : '—' }}</p>
+                                                </div>
+                                            </div>
+                                            <div class="space-y-4">
+                                                <div
+                                                    v-for="(part, partIndex) in selectedVersion.parts"
+                                                    :key="part.id || partIndex"
+                                                    class="rounded-2xl border border-slate-800 bg-slate-900/60 p-5"
+                                                >
+                                                    <div class="flex flex-wrap items-center justify-between gap-3">
+                                                        <div>
+                                                            <p class="text-sm font-semibold text-white">File {{ partIndex + 1 }}</p>
+                                                            <p class="text-xs text-slate-500 break-all">{{ part.file || 'Path unavailable' }}</p>
+                                                        </div>
+                                                        <div class="text-right text-xs text-slate-400">
+                                                            <p>{{ formatFileSize(part.size) }}</p>
+                                                            <p>{{ formatDuration(part.duration) }}</p>
+                                                        </div>
+                                                    </div>
+                                                    <p v-if="part.ffprobeError" class="mt-3 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+                                                        ffprobe error: {{ part.ffprobeError }}
+                                                    </p>
+                                                    <div v-else-if="part.streamSummary" class="mt-4 grid gap-4 lg:grid-cols-3">
+                                                        <div>
+                                                            <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Video Streams</p>
+                                                            <ul class="mt-2 space-y-2 text-xs text-slate-300" v-if="part.streamSummary.video.length">
+                                                                <li v-for="stream in part.streamSummary.video" :key="stream.id" class="rounded-md bg-slate-900/70 px-3 py-2">
+                                                                    {{ describeVideoStream(stream) }}
+                                                                </li>
+                                                            </ul>
+                                                            <p v-else class="mt-2 text-xs text-slate-500">No video streams reported.</p>
+                                                        </div>
+                                                        <div>
+                                                            <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Audio Tracks</p>
+                                                            <ul class="mt-2 space-y-2 text-xs text-slate-300" v-if="part.streamSummary.audio.length">
+                                                                <li v-for="stream in part.streamSummary.audio" :key="stream.id" class="rounded-md bg-slate-900/70 px-3 py-2">
+                                                                    {{ describeAudioStream(stream) }}
+                                                                </li>
+                                                            </ul>
+                                                            <p v-else class="mt-2 text-xs text-slate-500">No audio tracks detected.</p>
+                                                        </div>
+                                                        <div>
+                                                            <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Subtitles</p>
+                                                            <ul class="mt-2 space-y-2 text-xs text-slate-300" v-if="part.streamSummary.subtitles.length">
+                                                                <li v-for="stream in part.streamSummary.subtitles" :key="stream.id" class="rounded-md bg-slate-900/70 px-3 py-2">
+                                                                    {{ describeSubtitleStream(stream) }}
+                                                                </li>
+                                                            </ul>
+                                                            <p v-else class="mt-2 text-xs text-slate-500">No subtitle tracks detected.</p>
+                                                        </div>
+                                                    </div>
+                                                    <p v-else class="mt-3 text-xs text-slate-500">Stream analysis pending. Pull live EXIF to generate ffprobe data.</p>
+                                                    <div v-if="part.plexStreams && part.plexStreams.length" class="mt-4 space-y-2 text-xs text-slate-300">
+                                                        <p class="text-xs font-semibold uppercase tracking-wide text-slate-400">Plex Metadata</p>
+                                                        <div v-for="stream in part.plexStreams" :key="stream.id + '-' + stream.type" class="rounded-md border border-slate-800 bg-slate-900/50 px-3 py-2">
+                                                            <p class="font-semibold text-slate-100" v-if="stream.type === 'video'">Video Track</p>
+                                                            <p class="font-semibold text-slate-100" v-else-if="stream.type === 'audio'">Audio Track</p>
+                                                            <p class="font-semibold text-slate-100" v-else-if="stream.type === 'subtitle'">Subtitle</p>
+                                                            <p>{{ stream.extendedDisplayTitle || stream.displayTitle || (stream.codec ? stream.codec.toUpperCase() : 'Track') }}</p>
+                                                            <p v-if="stream.type === 'video' && stream.dolbyVision && stream.dolbyVision.present" class="text-indigo-200">
+                                                                Dolby Vision Profile {{ stream.dolbyVision.profile }} · Level {{ stream.dolbyVision.level }}
+                                                            </p>
+                                                            <p v-else-if="stream.type === 'video' && stream.dynamicRange" class="text-slate-400">
+                                                                {{ stream.dynamicRange }}
+                                                            </p>
+                                                            <p v-if="stream.type === 'video' && stream.colorPrimaries" class="text-slate-500">
+                                                                {{ stream.colorPrimaries }} · {{ stream.colorTrc || 'PQ' }} · {{ stream.bitDepth ? stream.bitDepth + '-bit' : '' }}
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <p v-else class="text-sm text-slate-500">No version metadata available for this title.</p>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+                    <p v-if="metadataError.list" class="mt-4 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
+                        {{ metadataError.list }}
+                    </p>
+                </section>
+
                 <section class="grid gap-6 lg:grid-cols-3">
                     <div class="col-span-2 space-y-6">
                         <div class="rounded-3xl border border-slate-800 bg-slateglass p-6 backdrop-blur-xl">
                             <h3 class="text-xl font-semibold text-white">Recent Dolby Vision Additions</h3>
                             <p class="text-sm text-slate-400">Latest titles enriched with Dolby Vision metadata.</p>
                             <div class="mt-4 space-y-3">
-                                <div v-for="item in metrics.recent" :key="item.title + item.updated_at" class="flex justify-between rounded-2xl border border-slate-800 bg-slate-900/60 px-4 py-3">
+                                <button
+                                    v-for="item in metrics.recent"
+                                    :key="item.title + item.updated_at"
+                                    type="button"
+                                    @click="openRecentMovie(item)"
+                                    class="flex w-full justify-between rounded-2xl border px-4 py-3 text-left transition"
+                                    :class="selectedMovie && item.rating_key && String(selectedMovie.ratingKey) === String(item.rating_key)
+                                        ? 'border-indigo-500 bg-indigo-500/10'
+                                        : 'border-slate-800 bg-slate-900/60 hover:border-slate-700 hover:bg-slate-900/80'"
+                                >
                                     <div>
                                         <p class="font-medium text-white">{{ item.title }}</p>
                                         <p class="text-xs text-slate-400">Profile {{ item.dv_profile || '—' }} · {{ item.has_atmos ? 'Atmos' : 'No Atmos' }} · {{ item.dv_fel ? 'FEL' : 'MEL' }}</p>
+                                        <div v-if="versionSummaryTags(getPreferredVersion(movieByRatingKey(item.rating_key))).length" class="mt-2 flex flex-wrap gap-2 text-[10px] font-medium uppercase tracking-wide">
+                                            <span
+                                                v-for="tag in versionSummaryTags(getPreferredVersion(movieByRatingKey(item.rating_key)))"
+                                                :key="tag"
+                                                class="rounded-full border px-2 py-0.5"
+                                                :class="tagBadgeClass(tag)"
+                                            >
+                                                {{ tag }}
+                                            </span>
+                                        </div>
                                     </div>
                                     <div class="text-right text-xs text-slate-500">
                                         <p>{{ formatRelative(item.updated_at) }}</p>
                                         <p v-if="item.file_size" class="text-slate-400">{{ item.file_size.toFixed(2) }} GB</p>
                                     </div>
-                                </div>
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -109,8 +384,8 @@
                                 <li class="flex justify-between"><span>Atmos coverage</span><span class="font-semibold text-sky-300">{{ metrics.ratios.atmos_percent }}%</span></li>
                                 <li class="flex justify-between"><span>DV + Atmos overlap</span><span class="font-semibold text-sky-300">{{ metrics.ratios.dv_and_atmos }}</span></li>
                                 <li class="flex justify-between"><span>FEL + Atmos overlap</span><span class="font-semibold text-sky-300">{{ metrics.ratios.fel_and_atmos }}</span></li>
-                                <li class="flex justify-between"><span>Average DV bitrate</span><span class="font-semibold text-emerald-300">{{ metrics.quality.avg_bitrate_mbps.toFixed(2) }} Mbps</span></li>
-                                <li class="flex justify-between"><span>Average DV file size</span><span class="font-semibold text-emerald-300">{{ metrics.quality.avg_file_size_gb.toFixed(2) }} GB</span></li>
+                                <li class="flex justify-between"><span>Median DV bitrate</span><span class="font-semibold text-emerald-300">{{ metrics.quality.median_bitrate_mbps.toFixed(2) }} Mbps</span></li>
+                                <li class="flex justify-between"><span>Median DV file size</span><span class="font-semibold text-emerald-300">{{ metrics.quality.median_file_size_gb.toFixed(2) }} GB</span></li>
                             </ul>
                         </div>
 


### PR DESCRIPTION
 ## Summary
  - add `metadata_service.py` to combine Plex XML and ffprobe stream data into a cached schema
  - expose `/api/movies` + `/api/movies/<ratingKey>` and wire the service into settings load/save
  - update Vue dashboard with metadata explorer (version picker, DV/Atmos filters, track summaries)
  - document ffprobe setup and new endpoints; guard new modules for future download manager work

  ## Testing
  - python3 -m compileall app.py metadata_service.py static/js/newgui-app.js
  - manual UI test: http://127.0.0.1:5656/ → Metadata Explorer
